### PR TITLE
fix: use correct require path for `reader` module

### DIFF
--- a/lua/codedocs/specs/reader.lua
+++ b/lua/codedocs/specs/reader.lua
@@ -1,4 +1,4 @@
-local opts = require("lua.codedocs.specs._langs.style_opts")
+local opts = require("codedocs.specs._langs.style_opts")
 
 local Reader = {}
 


### PR DESCRIPTION
closes #15