### PR TITLE
fix(specs/ruby): remove leading space in `YARD` function style

### DIFF
--- a/lua/codedocs/specs/_langs/ruby/func/styles/YARD.lua
+++ b/lua/codedocs/specs/_langs/ruby/func/styles/YARD.lua
@@ -1,7 +1,7 @@
 return function(opts)
 	return {
 		general = {
-			[opts.struct.val] = { " # ", " # " },
+			[opts.struct.val] = { "# ", "# " },
 			[opts.direction.val] = true,
 			[opts.title_pos.val] = 1,
 			[opts.title_gap.val] = true,


### PR DESCRIPTION
Ruby's `YARD` style for functions has a leading space before the "#" character. This doesn't break anything but makes the annotation look off and its unintended behaviour, which is why this fix was made.