### PR TITLE
chore: add simple debug logging

### DIFF
--- a/lua/codedocs/annotation_builder.lua
+++ b/lua/codedocs/annotation_builder.lua
@@ -1,3 +1,4 @@
+local Debug_logger = require("codedocs.utils.debug_logger")
 local opts = require("codedocs.specs._langs.style_opts")
 
 -- @param title string Section title
@@ -174,5 +175,7 @@ end
 
 return function(style, data, annotation_structure)
 	local annotation_content = _build_annotation_content(data, style)
+	Debug_logger.log("Annotation content:", annotation_content)
+
 	return _format_annotation_content(annotation_content, style, annotation_structure)
 end

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -1,3 +1,4 @@
+local Debug_logger = require("codedocs.utils.debug_logger")
 local docs_builder = require("codedocs.annotation_builder")
 local Spec = require("codedocs.specs")
 local Processor = require("codedocs.tree_processor")
@@ -5,12 +6,15 @@ local Processor = require("codedocs.tree_processor")
 local M = {}
 
 function M.setup(config)
+	if config.settings then Spec.customizer.set_settings(config.settings) end
+
 	if config and config.default_styles then Spec.customizer:set_default_lang_style(config.default_styles) end
 
 	if config and config.styles then Spec.customizer:update_style(config.styles) end
 end
 
 function M.insert_docs()
+	Debug_logger.log("Plugin triggered")
 	local lang = vim.bo.filetype
 	if not vim.treesitter.get_parser(0, lang, { error = false }) then
 		vim.notify("Tree-sitter parser for " .. lang .. " is not installed", vim.log.levels.ERROR)
@@ -22,15 +26,20 @@ function M.insert_docs()
 	if not struct_names then return false end
 
 	local struct_name, node = Processor:determine_struc_under_cursor(struct_names)
-	local style, opts, identifier_pos = Spec.reader:get_struct_data(lang, struct_name)
+	Debug_logger.log("Structure name: " .. struct_name)
 
-	local sections = style.general.section_order
-	local pos, data = Processor:item_parser(node, sections, struct_name, style, opts, identifier_pos)
+	local style, opts, identifier_pos = Spec.reader:get_struct_data(lang, struct_name)
+	Debug_logger.log("Style:", style)
+
+	local pos, data = Processor:item_parser(node, style.general.section_order, struct_name, style, opts, identifier_pos)
+	Debug_logger.log("Items:", data)
+
 	local struct = style.general[opts.struct.val]
 
 	local docs = (struct_name == "comment") and struct or docs_builder(style, data, struct)
+	Debug_logger.log("Annotation:", docs)
 
-	require("lua.codedocs.buf_writer")(docs, pos, style.general[opts.direction.val], style.general[opts.title_pos.val])
+	require("codedocs.buf_writer")(docs, pos, style.general[opts.direction.val], style.general[opts.title_pos.val])
 end
 
 return M

--- a/lua/codedocs/specs/customizer.lua
+++ b/lua/codedocs/specs/customizer.lua
@@ -69,4 +69,8 @@ function Customizer:update_style(user_opts)
 	end
 end
 
+function Customizer.set_settings(settings)
+	if settings.debug == true then require("codedocs.utils.debug_logger").enable() end
+end
+
 return Customizer

--- a/lua/codedocs/utils/debug_logger.lua
+++ b/lua/codedocs/utils/debug_logger.lua
@@ -1,0 +1,15 @@
+local is_debug_mode_on = false
+
+local Debug_logging = {}
+
+function Debug_logging.log(msg, tbl)
+	local log_msg = "[Codedocs Debug] " .. msg
+
+	if tbl and type(tbl) == "table" then log_msg = string.format("%s %s", log_msg, vim.inspect(tbl)) end
+
+	if is_debug_mode_on then vim.notify(log_msg, vim.log.levels.DEBUG) end
+end
+
+function Debug_logging.enable() is_debug_mode_on = true end
+
+return Debug_logging


### PR DESCRIPTION
There's been a lot of instances where I've needed to debug many components in the plugin, and the quickest way to do this is through print debugging, which gets the job done but is tedious, and sometimes I end up pushing print statements to `main`. By introducing logging I can toggle the logging of information that is useful for debugging, and don't have to worry ever again about manually adding or removing the statements (regex is unreliable for this).