### PR TITLE
ci(panvimdoc): make PR instead of commit directly

### DIFF
--- a/.github/workflows/panvimdoc.yaml
+++ b/.github/workflows/panvimdoc.yaml
@@ -1,4 +1,4 @@
-name: panvimdoc
+name: Auto-generate vim documentation
 
 on:
     push:
@@ -24,7 +24,12 @@ jobs:
                   demojify: true
                   version: "NVIM v0.10+"
 
-            - uses: stefanzweifel/git-auto-commit-action@v4
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v7
               with:
-                  commit_message: "Auto generate docs"
-                  branch: ${{ github.head_ref }}
+                  commit-message: "docs: auto-generate vimdoc"
+                  branch: "autogenerate-vim-doc"
+                  title: "docs: auto-generate vimdoc"
+                  body: "This pull request contains auto-generated Vim documentation"
+                  labels: "documentation"
+                  author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Description

Update the `panvimdoc` workflow so that it creates a PR instead of a commit

## Changes

- Updates the `panvimdoc` workflow so that it creates a PR with the updated vim documentation instead of pushing the commit (Main would reject it)

## Breaking changes

- [ ] Yes
- [x] No
