### PR TITLE
ci: add pull request write permissions to `panvimdoc` workflow

### DIFF
--- a/.github/workflows/panvimdoc.yaml
+++ b/.github/workflows/panvimdoc.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
     contents: write
+    pull-requests: write
 
 jobs:
     docs:


### PR DESCRIPTION
## Description

The `panvimdoc` workflow can't create PR's without write permissions

## Changes

- Adds pull request write permissions to the `panvimdoc` workflow

## Breaking changes

- [ ] Yes
- [x] No
