### PR TITLE
refactor: apply design-by-contract preconditions to most components

### DIFF
--- a/lua/codedocs/annotation_builder.lua
+++ b/lua/codedocs/annotation_builder.lua
@@ -1,12 +1,21 @@
 local Debug_logger = require("codedocs.utils.debug_logger")
 
 local function _handle_string(string, item_name, item_type, include_type)
+	assert(type(string) == "string", "'string' must be a string, got " .. type(string))
+	assert(type(item_name) == "string", "'item_name' must be a string, got " .. type(item_name))
+	assert(type(item_type) == "string", "'item_type' must be a string, got " .. type(item_type))
+	assert(type(include_type) == "boolean", "'include_type' must be a string, got " .. type(include_type))
+
 	local result = string:gsub("%%item_name", item_name or "")
 	result = include_type and result:gsub("%%item_type", item_type or "") or result:gsub("%%item_type", "")
 	return result
 end
 
 local function _build_line(line, item, opts)
+	assert(type(line) == "string" or type(line) == "table", "'line' must be a table or a string, got " .. type(line))
+	assert(type(item) == "table", "'item' must be a table, got " .. type(item))
+	assert(type(opts) == "table", "'opts' must be a table, got " .. type(opts))
+
 	local line_type = type(line)
 
 	if line_type == "string" then return _handle_string(line, item.name, item.type, opts.items.include_type) end
@@ -29,6 +38,9 @@ end
 -- @param style table Style configuration for all sections and general options
 -- @return table Table mapping section names to their formatted content lines
 local function _build_annotation_content(item_data, style)
+	assert(type(item_data) == "table", "'item_data' must be a table, got " .. type(item_data))
+	assert(type(style) == "table", "'style' must be a table, got " .. type(style))
+
 	local annotation_content = {}
 
 	for section_idx, section_name in ipairs(style.general.section_order) do
@@ -68,6 +80,13 @@ end
 ---@param title_opts table Title section opts
 ---@return string[] annotation Final formatted annotation as a flat list of lines
 local function _format_annotation_content(annotation_layout, content, insert_at, title_opts)
+	assert(type(annotation_layout) == "table", "'annotation_layout' must be a table, got " .. type(annotation_layout))
+	assert(type(content) == "table", "'content' must be a table, got " .. type(content))
+	assert(type(title_opts) == "table", "'title_opts' must be a table, got " .. type(title_opts))
+
+	assert(type(insert_at) == "number", "'insert_at' must be a number, got " .. type(insert_at))
+	assert(insert_at >= 0, "'insert_at' must be 0 or higher, got " .. insert_at)
+
 	local annotation = {}
 
 	for i = 1, (insert_at - 1) do

--- a/lua/codedocs/buf_writer.lua
+++ b/lua/codedocs/buf_writer.lua
@@ -1,4 +1,19 @@
+---TODO: Possible improvement, annotation_base_row + title_relative_row could be abstracted away at the caller
 local function move_cursor_to_title(annotation_base_row, title_relative_row, insert_above)
+	assert(type(insert_above) == "boolean", "'insert_above' must be a boolean, got " .. type(insert_above))
+
+	assert(
+		type(annotation_base_row) == "number",
+		"'annotation_base_row' must be a number, got " .. type(annotation_base_row)
+	)
+	assert(annotation_base_row >= 0, "'annotation_base_row' must be 0 or higher, got " .. annotation_base_row)
+
+	assert(
+		type(title_relative_row) == "number",
+		"'title_relative_row' must be a number, got " .. type(title_relative_row)
+	)
+	assert(title_relative_row >= 0, "'title_relative_row' must be 0 or higher, got " .. title_relative_row)
+
 	local title_row = annotation_base_row + title_relative_row
 	local target_row = insert_above and title_row or (title_row + 1)
 
@@ -8,6 +23,9 @@ local function move_cursor_to_title(annotation_base_row, title_relative_row, ins
 end
 
 local function compute_line_indent(line_row)
+	assert(type(line_row) == "number", "'line_row' must be a number, got " .. type(line_row))
+	assert(line_row >= 0, "'line_row' must be 0 or higher, got " .. line_row)
+
 	local cols = vim.fn.indent(line_row)
 
 	if vim.bo.expandtab then return string.rep(" ", cols) end
@@ -20,6 +38,10 @@ local function compute_line_indent(line_row)
 end
 
 local function add_indent_to_docs(annotation, base_indent, insert_above)
+	assert(type(annotation) == "table", "'annotation' must be a table, got " .. type(annotation))
+	assert(type(base_indent) == "string", "'base_indent' must be a string, got " .. type(base_indent))
+	assert(type(insert_above) == "boolean", "'insert_above' must be a boolean, got " .. type(insert_above))
+
 	local extra_indent
 	if insert_above then
 		extra_indent = ""
@@ -54,6 +76,12 @@ end
 -- @param insert_above boolean If true, insert above the structure; otherwise below
 -- @param title_pos integer Row offset of the title line within the annotation
 return function(annotation, row, insert_above, title_pos)
+	assert(type(annotation) == "table", "'annotation' must be a string, got " .. type(annotation))
+	assert(type(insert_above) == "boolean", "'insert_above' must be a boolean, got " .. type(insert_above))
+
+	assert(type(row) == "number", "'row' must be a number, got " .. type(row))
+	assert(row >= 0, "'row' must be 0 or higher, got " .. row)
+
 	local structure_indent_string = compute_line_indent(row + 1)
 	local indented_docs = add_indent_to_docs(annotation, structure_indent_string, insert_above)
 

--- a/lua/codedocs/struct_detector.lua
+++ b/lua/codedocs/struct_detector.lua
@@ -2,6 +2,11 @@
 -- @return string Structure name
 -- @return vim.treesitter._tsnode
 return function(struct_identifiers)
+	assert(
+		type(struct_identifiers) == "table",
+		"struct_identifiers must be a table (got " .. type(struct_identifiers) .. ")"
+	)
+
 	vim.treesitter.get_parser(0):parse()
 	local node_at_cursor = vim.treesitter.get_node()
 

--- a/lua/codedocs/utils/debug_logger.lua
+++ b/lua/codedocs/utils/debug_logger.lua
@@ -3,6 +3,9 @@ local is_debug_mode_on = false
 local Debug_logging = {}
 
 function Debug_logging.log(msg, tbl)
+	assert(type(msg) == "string", "'msg' must be a string, got " .. type(msg))
+	assert(tbl == nil or type(tbl) == "table", "'tbl' must be a string, got " .. type(tbl))
+
 	local log_msg = "[Codedocs Debug] " .. msg
 
 	if tbl and type(tbl) == "table" then log_msg = string.format("%s %s", log_msg, vim.inspect(tbl)) end


### PR DESCRIPTION
## Description

Functions used internally have worked properly so far but they are not inherently safe as they don't check that their arguments are correct, meaning invalid values can be propagated throughout the system, and debugging wouldn't be as straightforward as it could be. This PR aims to improve this.

## Changes

- All function preconditions are validated using `assert` in all components except `Spec`; this exception is because the `Spec` component is the core of the plugin, meaning a change of this type is gonna have a greater effect, positive or negative, throughout the system, and this change is just a prototype for now.
## Breaking changes

- [ ] Yes
- [x] No
