### PR TITLE
docs: improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ formats, or just use codedocs as it is! :)
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [Language support](#language-support)
+- [Annotation examples](#annotation-examples)
 - [Roadmap](#roadmap)
 - [Technical documentation](./lua/codedocs/README.md)
 - [Contributing](#contributing)
@@ -363,9 +364,6 @@ vim.keymap.set(
 
 ## Language support
 
-> [!TIP]
-> Want to see how annotations look by default? Take a look at the [Annotation Examples](./ANNOTATION_EXAMPLES.md)
-
 <!-- prettier-ignore -->
 > [!NOTE]
 > \* indicates the default style for that language
@@ -385,6 +383,11 @@ vim.keymap.set(
 | Ruby       | \*YARD                | `comment`, `function`          |
 | Rust       | \*RustDoc             | `comment`, `function`          |
 | TypeScript | \*TSDoc               | `comment`, `function`, `class` |
+
+## Annotation examples
+
+Want to see what annotations look like across all languages and styles? Check out
+[Annotation Examples](./ANNOTATION_EXAMPLES.md).
 
 ## Roadmap
 


### PR DESCRIPTION
## Description

The project's README isn't as organized and easy to understand as it could be, specially the configuration section. This PR aims to fix that

## Changes

- Adds the `annotation examples` section
- Remove emojis as to not conflict with `markdownlint`
- The `supported languages` section is now called `Language support` as to make it more general since it also includes styles and structures
- The configuration section contains the exact same information as before, just in more organized and easier to understand format

## Breaking changes

- [ ] Yes
- [x] No
