### PR TITLE
feat: add annotation selection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ def cool_function_with_type_hints(a: int, b: bool) -> str:
 
 In this case, we:
 
-- Increased spacing between items in the parameters section.
+- Increased spacing between items in the parameters block.
 - Wrapped parameter types with two [Kaomojis](https://kaomoji.ru/en/).
 - Added a third kaomoji to wrap the left side of the return type.
-- Customized the titles for both the parameters and return sections.
+- Customized the titles for both the parameters and return blocks.
 
 To customize an annotation, keep in mind that it is simply a regular Lua
 table with the following options:
@@ -224,46 +224,46 @@ table with the following options:
 | ------------------- | --------------------------------------------------- | ------------------------------------------------- |
 | `relative_position` | `"above"` \| `"below"` \| `"empty_target_or_above"` | Where to insert the annotation                    |
 | `indented`          | boolean                                             | Whether to indent the entire annotation one level |
-| `sections`          | table (list)                                        | List of sections forming the annotation           |
+| `blocks`            | table (list)                                        | List of blocks forming the annotation             |
 
-Sections are the core of an annotation, they determine what it ultimately looks
+Blocks are the core of an annotation, they determine what it ultimately looks
 like.
 
-#### Sections
+#### Blocks
 
 > [!WARNING]
-> The `sections` option is a list, so you cannot override a single section on its
-> own. Because your config is merged recursively with the defaults, any sections
+> The `blocks` option is a list, so you cannot override a single block on its
+> own. Because your config is merged recursively with the defaults, any blocks
 > you do not explicitly include will be removed, even if they exist in the defaults.
 >
-> To customize just one section, you should copy the default sections list and then
-> modify the specific section you want.
+> To customize just one block, you should copy the default blocks list and then
+> modify the specific block you want.
 >
-> Previously, `sections` was defined as a key value table, where the key represented
-> the section name (equivalent to the `name` field) and the value contained its
-> options (`layout`, `items`, etc.). While this made individual sections easier
+> Previously, `blocks` was defined as a key value table, where the key represented
+> the block name (equivalent to the `name` field) and the value contained its
+> options (`layout`, `items`, etc.). While this made individual blocks easier
 > to override, it made ordering difficult without introducing an additional option
 > (there used to be an option called `section_order` for this), and reduced composability.
 >
 > The current list based approach improves ordering and flexibility overall, at
-> the cost of making single section customization less convenient.
+> the cost of making single block customization less convenient.
 
-| Option Name          | Expected Type | Behavior                                                        |
-| -------------------- | ------------- | --------------------------------------------------------------- |
-| `name`               | string        | The name of the section, useful for readability and for items\* |
-| `layout`             | string[]      | List of lines that that make up the section                     |
-| `insert_gap_between` | table         | Sets up a gap in between the current section/item and the next  |
-| `ignore_prev_gap`    | boolean       | Skips the gap defined by the previous section (if enabled)      |
-| `items`              | table?        | Sets up options for the section's items                         |
+| Option Name          | Expected Type | Behavior                                                     |
+| -------------------- | ------------- | ------------------------------------------------------------ |
+| `name`               | string        | The name of the block, useful for readability and for items  |
+| `layout`             | string[]      | List of lines that that make up the block                    |
+| `insert_gap_between` | table         | Sets up a gap in between the current block/item and the next |
+| `ignore_prev_gap`    | boolean       | Skips the gap defined by the previous block (if enabled)     |
+| `items`              | table?        | Sets up options for the block's items                        |
 
 All options with the exception of `ignore_prev_gap` have some caveats that will
 be explained below in detail.
 
 ##### `items` option
 
-When a section uses the `items` option, it is considered an "item-based" section,
+When a block uses the `items` option, it is considered an "item-based" block,
 as it includes items extracted at runtime from a structure defined in its layout.
-In contrast, non-item-based sections consist solely of the lines defined in their
+In contrast, non-item-based blocks consist solely of the lines defined in their
 `layout`.
 
 An item represents a named component of a structure, defined by a `name` and a `type`.
@@ -300,21 +300,21 @@ has the following items:
 
 The `insert_gap_between` and `layout` options can be reused as suboptions of the
 `items` option; in such case the `layout` option would represent the lines that
-make up each item and that will be appended to the section's `layout` option.
+make up each item and that will be appended to the block's `layout` option.
 
 ##### `insert_gap_between` option
 
 The following suboptions are available:
 
-| Name    | Expected Value Type | Behavior                                                   |
-| ------- | ------------------- | ---------------------------------------------------------- |
-| enabled | `boolean`           | Whether a gap is inserted in between two sections or items |
-| text    | `string`            | String used as the gap                                     |
+| Name    | Expected Value Type | Behavior                                                 |
+| ------- | ------------------- | -------------------------------------------------------- |
+| enabled | `boolean`           | Whether a gap is inserted in between two blocks or items |
+| text    | `string`            | String used as the gap                                   |
 
 ##### `layout` option
 
 > [!INFO]
-> The layout lines of all sections are concatenated in section order to form the
+> The layout lines of all blocks are concatenated in block order to form the
 > final annotation.
 
 The following string placeholders are predefined:
@@ -335,16 +335,16 @@ When used, they get replaced by the item's name and type respectively.
 
 The `name` option serves two main purposes:
 
-1. Identifies the section, making it easier to understand its role
-2. Associates the section with a specific group of items extracted from a structure
+1. Identifies the block, making it easier to understand its role
+2. Associates the block with a specific group of items extracted from a structure
 
-The second purpose applies only to item-based sections. When items are extracted
-from a structure, they are grouped by section name. For these items to be included,
-the value of `name` must match the corresponding structure section.
+The second purpose applies only to item-based blocks. When items are extracted
+from a structure, they are grouped by block name. For these items to be included,
+the value of `name` must match the corresponding structure block.
 
-The following structure sections are available:
+The following structure blocks are available:
 
-| Structure | Sections                         |
+| Structure | blocks                           |
 | --------- | -------------------------------- |
 | `func`    | `title`, `parameters`, `returns` |
 | `class`   | `title`, `attributes`            |
@@ -356,8 +356,8 @@ Say we want to make the following changes to the `func` annotation for Python's
 Google style:
 
 - Add a gap in between all items.
-- Add a gap in between sections (functions have a `parameters` and `returns`
-  section)
+- Add a gap in between blocks (functions have a `parameters` and `returns`
+  block)
 
 This is what such customization would look like:
 
@@ -369,7 +369,7 @@ require("codedocs").setup({
                 definitions = {
                     Google = {
                         func = {
-                            sections = {
+                            blocks = {
                                  {
                                     name = "parameters",
                                     insert_gap_between = {

--- a/README.md
+++ b/README.md
@@ -401,24 +401,20 @@ require("codedocs").setup({
 
 ## Usage
 
-When an annotation insertion is triggered, the plugin generates one for the
-structure under the cursor. If no supported structure is detected, it inserts an
-inline comment instead.
+An annotation insertion can be triggered using the `:Codedocs` command. There are
+two ways to use the command:
 
-An annotation insertion can be triggered in the following ways:
+- **Without arguments**: The plugin attempts to detect the code structure under
+  the cursor, determines the default style for the current file’s language, and
+  applies the corresponding annotation. If no structure is recognized under the
+  cursor, an inline comment is inserted. By default, a matching annotation exists
+  for each structure unless you’ve customized the configuration.
 
-### Command
+- **With an annotation name**: You can pass the name of any annotation definition
+  defined in the language’s default style. The plugin will generate and insert the
+  annotation using that definition.
 
-The simplest way to use the plugin is with the following command:
-
-```lua
-:Codedocs
-```
-
-### Keymap
-
-For a more convenient experience, you can bind the annotation insertion to a
-keymap. For example:
+For a more convenient experience, you can bind the command to a keymap. For example:
 
 ```lua
 vim.keymap.set(

--- a/README.md
+++ b/README.md
@@ -425,11 +425,7 @@ vim.keymap.set(
 
 ## Language support
 
-<!-- prettier-ignore -->
-> [!NOTE]
-> \* indicates the default style for that language
-
-| Language   | Styles                | Built-in annotations           |
+| Language   | Styles (\* = default) | Built-in annotations           |
 | ---------- | --------------------- | ------------------------------ |
 | Bash       | \*Google              | `comment`, `function`          |
 | C          | \*Doxygen             | `comment`, `function`          |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ require("paq") {
 ## Configuration
 
 > [!WARNING]
-> Language, struct and style names must be spelled exactly as shown in the
+> Language, annotation and style names must be spelled exactly as shown in the
 > [supported languages section](#language-support).
 
 All options can be customized using the setup function. Here are most of the
@@ -136,7 +136,7 @@ require("codedocs").setup {
 }
 ```
 
-### Change a language's default annotation style
+### Change a language's default style
 
 Default styles are defined using the `default_styles` key:
 
@@ -171,11 +171,11 @@ require("codedocs").setup {
 }
 ```
 
-### Customize an annotation style
+### Customize an annotation
 
-You can customize almost (for now!) every aspect of an annotation
-style. Whether you want to make a simple change, like modifying the characters
-wrapping the parameter type:
+You can customize almost (for now!) every aspect of an annotation. Whether you
+want to make a simple change, like modifying the characters wrapping the parameter
+type:
 
 ```python
 def cool_function_with_type_hints(a: int, b: bool) -> str:
@@ -217,7 +217,7 @@ In this case, we:
 - Added a third kaomoji to wrap the left side of the return type.
 - Customized the titles for both the parameters and return sections.
 
-To customize an annotation style, keep in mind that it is simply a regular Lua
+To customize an annotation, keep in mind that it is simply a regular Lua
 table with the following options:
 
 | Option Name         | Expected Value Type                                 | Behavior                                          |
@@ -352,8 +352,8 @@ The following structure sections are available:
 
 #### Customization example
 
-Say we want to make the following changes to Python's Google annotation style
-for functions:
+Say we want to make the following changes to the `func` annotation for Python's
+Google style:
 
 - Add a gap in between all items.
 - Add a gap in between sections (functions have a `parameters` and `returns`
@@ -429,7 +429,7 @@ vim.keymap.set(
 > [!NOTE]
 > \* indicates the default style for that language
 
-| Language   | Styles                | Structures                     |
+| Language   | Styles                | Built-in annotations           |
 | ---------- | --------------------- | ------------------------------ |
 | Bash       | \*Google              | `comment`, `function`          |
 | C          | \*Doxygen             | `comment`, `function`          |

--- a/lua/codedocs/annotation_builder.lua
+++ b/lua/codedocs/annotation_builder.lua
@@ -77,46 +77,46 @@ local function format_item_line(line, item)
 	return line
 end
 
-local function _should_insert_gap_between_sections(section_idx, style, section_style, item_data)
-	local current_section_is_last = section_idx == #style.sections
-	if current_section_is_last then return false end
+local function _should_insert_gap_between_blocks(block_idx, style, block_style, item_data)
+	local current_block_is_last = block_idx == #style.blocks
+	if current_block_is_last then return false end
 
-	local next_section = style.sections[section_idx + 1]
-	local next_section_is_item_based = next_section and type(next_section.items) == "table"
-	if not next_section_is_item_based then
-		return section_style.insert_gap_between.enabled and not next_section.ignore_prev_gap
+	local next_block = style.blocks[block_idx + 1]
+	local next_block_is_item_based = next_block and type(next_block.items) == "table"
+	if not next_block_is_item_based then
+		return block_style.insert_gap_between.enabled and not next_block.ignore_prev_gap
 	end
 
-	local next_section_has_items = item_data[next_section.name] and #item_data[next_section.name] > 0
+	local next_block_has_items = item_data[next_block.name] and #item_data[next_block.name] > 0
 
-	if not next_section_has_items then return false end
+	if not next_block_has_items then return false end
 
-	if #next_section.layout == 0 and #next_section.items.layout == 0 then return false end
+	if #next_block.layout == 0 and #next_block.items.layout == 0 then return false end
 
-	return section_style.insert_gap_between.enabled and not next_section.ignore_prev_gap
+	return block_style.insert_gap_between.enabled and not next_block.ignore_prev_gap
 end
 
-local function _add_section_content(content, item_data, section_style)
-	local section_items = item_data[section_style.name]
-	local is_item_based_section = type(section_style.items) == "table"
-	if not is_item_based_section then
-		vim.list_extend(content, section_style.layout)
+local function _add_block_content(content, item_data, block_style)
+	local block_items = item_data[block_style.name]
+	local is_item_based_block = type(block_style.items) == "table"
+	if not is_item_based_block then
+		vim.list_extend(content, block_style.layout)
 		return
 	end
 
-	if section_items and #section_items > 0 then
-		for _, ln in ipairs(section_style.layout) do
+	if block_items and #block_items > 0 then
+		for _, ln in ipairs(block_style.layout) do
 			table.insert(content, ln)
 		end
 
-		for item_idx, item in ipairs(section_items) do
-			for _, line in ipairs(section_style.items.layout) do
+		for item_idx, item in ipairs(block_items) do
+			for _, line in ipairs(block_style.items.layout) do
 				local item_line = format_item_line(line, item)
 				table.insert(content, item_line)
 
-				local should_insert_item_gap = section_style.items.insert_gap_between.enabled
-					and section_items[item_idx + 1]
-				if should_insert_item_gap then table.insert(content, section_style.items.insert_gap_between.text) end
+				local should_insert_item_gap = block_style.items.insert_gap_between.enabled
+					and block_items[item_idx + 1]
+				if should_insert_item_gap then table.insert(content, block_style.items.insert_gap_between.text) end
 			end
 		end
 	end
@@ -125,23 +125,23 @@ end
 local function _build_content(item_data, style)
 	local content = {}
 
-	for section_idx, section_style in ipairs(style.sections) do
-		_add_section_content(content, item_data, section_style)
+	for block_idx, block_style in ipairs(style.blocks) do
+		_add_block_content(content, item_data, block_style)
 
-		if _should_insert_gap_between_sections(section_idx, style, section_style, item_data) then
-			table.insert(content, section_style.insert_gap_between.text)
+		if _should_insert_gap_between_blocks(block_idx, style, block_style, item_data) then
+			table.insert(content, block_style.insert_gap_between.text)
 		end
 	end
 
 	return content
 end
 
---- Builds the raw annotation content for each section, without applying the final structure
--- Iterates through the sections in the configured order, formats each item according to
--- its section style, and groups the resulting lines by section name
--- @param item_data table Mapping of section names to item lists
--- @param style table Style configuration for all sections and settings options
--- @return table Table mapping section names to their formatted content lines
+--- Builds the raw annotation content for each block, without applying the final structure
+-- Iterates through the blocks in the configured order, formats each item according to
+-- its block style, and groups the resulting lines by block name
+-- @param item_data table Mapping of block names to item lists
+-- @param style table Style configuration for all blocks and settings options
+-- @return table Table mapping block names to their formatted content lines
 return function(style, item_data, struct_data)
 	assert(type(item_data) == "table", "'item_data' must be a table, got " .. type(item_data))
 	assert(type(style) == "table", "'style' must be a table, got " .. type(style))

--- a/lua/codedocs/annotation_builder.lua
+++ b/lua/codedocs/annotation_builder.lua
@@ -81,20 +81,19 @@ local function _should_insert_gap_between_sections(section_idx, style, section_s
 	local current_section_is_last = section_idx == #style.sections
 	if current_section_is_last then return false end
 
-	local next_section_is_item_based = type(style.sections[section_idx + 1].items) == "table"
+	local next_section = style.sections[section_idx + 1]
+	local next_section_is_item_based = next_section and type(next_section.items) == "table"
 	if not next_section_is_item_based then
-		return section_style.insert_gap_between.enabled and not style.sections[section_idx + 1].ignore_prev_gap
+		return section_style.insert_gap_between.enabled and not next_section.ignore_prev_gap
 	end
 
-	local next_section_has_items = #item_data[style.sections[section_idx + 1].name] > 0
+	local next_section_has_items = item_data[next_section.name] and #item_data[next_section.name] > 0
 
 	if not next_section_has_items then return false end
 
-	if #style.sections[section_idx + 1].layout == 0 and #style.sections[section_idx + 1].items.layout == 0 then
-		return false
-	end
+	if #next_section.layout == 0 and #next_section.items.layout == 0 then return false end
 
-	return section_style.insert_gap_between.enabled and not style.sections[section_idx + 1].ignore_prev_gap
+	return section_style.insert_gap_between.enabled and not next_section.ignore_prev_gap
 end
 
 local function _add_section_content(content, item_data, section_style)

--- a/lua/codedocs/config/languages/bash/Google.lua
+++ b/lua/codedocs/config/languages/bash/Google.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			language_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			language_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/c/Doxygen.lua
+++ b/lua/codedocs/config/languages/c/Doxygen.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/cpp/Doxygen.lua
+++ b/lua/codedocs/config/languages/cpp/Doxygen.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/go/Godoc.lua
+++ b/lua/codedocs/config/languages/go/Godoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {

--- a/lua/codedocs/config/languages/java/JavaDoc.lua
+++ b/lua/codedocs/config/languages/java/JavaDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -47,7 +47,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/javascript/JSDoc.lua
+++ b/lua/codedocs/config/languages/javascript/JSDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -51,7 +51,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {

--- a/lua/codedocs/config/languages/kotlin/KDoc.lua
+++ b/lua/codedocs/config/languages/kotlin/KDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -47,7 +47,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/lua/EmmyLua.lua
+++ b/lua/codedocs/config/languages/lua/EmmyLua.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {

--- a/lua/codedocs/config/languages/lua/LDoc.lua
+++ b/lua/codedocs/config/languages/lua/LDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {

--- a/lua/codedocs/config/languages/php/PHPDoc.lua
+++ b/lua/codedocs/config/languages/php/PHPDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/python/Google.lua
+++ b/lua/codedocs/config/languages/python/Google.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "below",
 		indented = true,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -48,7 +48,7 @@ return {
 	func = {
 		relative_position = "below",
 		indented = true,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/python/Numpy.lua
+++ b/lua/codedocs/config/languages/python/Numpy.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "below",
 		indented = true,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -45,7 +45,7 @@ return {
 	func = {
 		relative_position = "below",
 		indented = true,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/python/reST.lua
+++ b/lua/codedocs/config/languages/python/reST.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indented = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "below",
 		indented = true,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -45,7 +45,7 @@ return {
 	func = {
 		relative_position = "below",
 		indented = true,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/config/languages/ruby/YARD.lua
+++ b/lua/codedocs/config/languages/ruby/YARD.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {

--- a/lua/codedocs/config/languages/rust/RustDoc.lua
+++ b/lua/codedocs/config/languages/rust/RustDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	func = {
 		relative_position = "above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {

--- a/lua/codedocs/config/languages/typescript/TSDoc.lua
+++ b/lua/codedocs/config/languages/typescript/TSDoc.lua
@@ -4,7 +4,7 @@ return {
 	comment = {
 		relative_position = "empty_target_or_above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "title",
 				layout = {
@@ -16,7 +16,7 @@ return {
 	class = {
 		relative_position = "above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {
@@ -48,7 +48,7 @@ return {
 	func = {
 		relative_position = "above",
 		indent = false,
-		sections = {
+		blocks = {
 			lang_utils.new_section {
 				name = "header",
 				layout = {

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -58,7 +58,7 @@ local function _get_supported_struct_node_data(ts_node, struct_identifiers)
 
 	local struct_name = struct_identifiers[ts_node:type()]
 
-	if struct_name then return { name = struct_name, node = ts_node, pos = ts_node:range() } end
+	if struct_name then return { name = struct_name, node = ts_node } end
 
 	return _get_supported_struct_node_data(ts_node:parent(), struct_identifiers)
 end
@@ -80,16 +80,21 @@ function Codedocs.setup(user_config)
 	end
 end
 
-function Codedocs.extract_item_data(lang_name)
+function Codedocs.extract_item_data(lang_name, struct_name)
 	vim.treesitter.get_parser(0):parse()
 	local node_at_cursor = vim.treesitter.get_node()
 
 	local struct_data = _get_supported_struct_node_data(node_at_cursor, Codedocs.get_struct_identifiers(lang_name))
-		or { name = "comment" }
 
-	if struct_data.name == "comment" then return {}, struct_data.name, vim.api.nvim_win_get_cursor(0)[1] - 1 end
+	local cursor_row = vim.api.nvim_win_get_cursor(0)[1] - 1
+
+	if not struct_data then return {}, struct_name or "comment", cursor_row end
+
+	if struct_name and struct_data.name ~= struct_name then return {}, struct_name, cursor_row end
 
 	local lang_config = require("codedocs.config").languages[lang_name]
+
+	local struct_pos = struct_data.node:range()
 
 	local item_extractors = lang_config.structures[struct_data.name].extractors
 	local items_data = require "codedocs.item_extractor"(
@@ -100,14 +105,18 @@ function Codedocs.extract_item_data(lang_name)
 	)
 
 	Debug_logger.log("Item data: ", items_data)
-	return items_data, struct_data.name, struct_data.pos
+	return items_data, struct_data.name, struct_pos
 end
 
 function Codedocs.orchestrate_annotation_build(lang_data)
 	local lang_spec = LangSpecs.new(lang_data.name)
 
-	local items_data, struct_name, row = Codedocs.extract_item_data(lang_data.name)
-	local struct_style = lang_spec:get_struct_style(struct_name, lang_data.style_name or lang_spec:get_default_style())
+	local items_data, struct_name, annotation_row = Codedocs.extract_item_data(lang_data.name, lang_data.substyle_name)
+
+	local struct_style = lang_spec:get_struct_style(
+		lang_data.substyle_name or struct_name,
+		lang_data.style_name or lang_spec:get_default_style()
+	)
 
 	Debug_logger.log("Structure name: " .. struct_name)
 	Debug_logger.log("Style name: " .. lang_spec:get_default_style())
@@ -115,15 +124,15 @@ function Codedocs.orchestrate_annotation_build(lang_data)
 
 	local struct_data = {
 		should_indent = struct_style.indented,
-		line_num = row + 1,
+		line_num = annotation_row + 1,
 	}
 
 	local annotation_lines = docs_builder(struct_style, items_data, struct_data)
 
-	return annotation_lines, row, struct_style.relative_position
+	return annotation_lines, annotation_row, struct_style.relative_position
 end
 
-function Codedocs.insert_docs()
+function Codedocs.insert_docs(substyle_name)
 	Debug_logger.log "Plugin triggered"
 
 	local lang_name = require("codedocs.config").aliases[vim.bo.filetype] or vim.bo.filetype
@@ -134,7 +143,9 @@ function Codedocs.insert_docs()
 		return
 	end
 
-	local annotation_lines, row, relative_position = Codedocs.orchestrate_annotation_build { name = lang_name }
+	local annotation_lines, row, relative_position =
+		Codedocs.orchestrate_annotation_build { name = lang_name, substyle_name = substyle_name }
+
 	Debug_logger.log("Annotation:", annotation_lines)
 
 	_write_to_buffer(annotation_lines, row, relative_position)

--- a/plugin/codedocs.lua
+++ b/plugin/codedocs.lua
@@ -20,4 +20,25 @@ vim.api.nvim_set_keymap(
 	"<cmd>lua require('codedocs').insert_docs()<CR>",
 	{ noremap = true, silent = true }
 )
-vim.api.nvim_create_user_command("Codedocs", require("codedocs").insert_docs, {})
+local function get_annotation_list()
+	local lang = vim.bo.filetype
+	local lang_stuff = require("codedocs.config").languages[lang]
+	local substyles = vim.tbl_keys(lang_stuff.styles.definitions[lang_stuff.styles.default])
+	print(vim.inspect(substyles))
+	return substyles
+end
+
+vim.api.nvim_create_user_command("Codedocs", function(opts)
+	local choice = opts.fargs[1]
+	if choice and not vim.tbl_contains(get_annotation_list(), choice) then
+		vim.notify("Invalid option: " .. (choice or "nil"), vim.log.levels.ERROR)
+		return
+	end
+	require("codedocs").insert_docs(choice)
+end, {
+	nargs = "?",
+	complete = function(arglead)
+		print(vim.inspect(get_annotation_list()))
+		return vim.tbl_filter(function(opt) return opt:find(arglead) == 1 end, get_annotation_list())
+	end,
+})

--- a/tests/annotation_builder_spec.lua
+++ b/tests/annotation_builder_spec.lua
@@ -65,7 +65,7 @@ local BASE_ANNOTATION = {
 	},
 	opts = {
 		settings = {},
-		sections = {
+		blocks = {
 			{
 				name = "title",
 				layout = {
@@ -146,7 +146,7 @@ local CASES = {
 		},
 		opts_to_change = {
 			settings = {},
-			sections = {
+			blocks = {
 				{
 					name = "header",
 					layout = {
@@ -243,7 +243,7 @@ local CASES = {
 			" */",
 		},
 		opts_to_change = {
-			sections = {
+			blocks = {
 				{
 					name = "header",
 					layout = {
@@ -334,7 +334,7 @@ local CASES = {
 		},
 		opts_to_change = {
 			settings = {},
-			sections = {
+			blocks = {
 				{
 					name = "header",
 					layout = {
@@ -431,7 +431,7 @@ local CASES = {
 			" */",
 		},
 		opts_to_change = {
-			sections = {
+			blocks = {
 				{
 					name = "header",
 					layout = {
@@ -518,7 +518,7 @@ local CASES = {
 			" */",
 		},
 		opts_to_change = {
-			sections = {
+			blocks = {
 				{
 					name = "header",
 					layout = {
@@ -596,7 +596,7 @@ local CASES = {
 			" */",
 		},
 		opts_to_change = {
-			sections = {
+			blocks = {
 				{
 					name = "header",
 					layout = {

--- a/tests/specs/user_config/change_annotation_style_opts_spec.lua
+++ b/tests/specs/user_config/change_annotation_style_opts_spec.lua
@@ -20,7 +20,7 @@ local BASE_MOCKED_OPTS = {
 			relative_position = "above",
 			insert_at = 3,
 		},
-		sections = {
+		blocks = {
 			title = {
 				layout = {
 					"--------",


### PR DESCRIPTION
## Description

Codedocs could only generate annotations when a language structure was detected under the cursor, making the `comment` annotation little more than a fallback, and making the addition of annotations not related to structures complicated. This update expands the `:Codedocs` command and paves the way for a lot of new features.

## Changes

- Renames the `sections` option to `blocks` to reduce ambiguity with documentation sections or other terms
- The `:Codedocs` command can now receive as arguments the names of the annotations available in the language's default style

## Breaking changes

- [x] Yes
- [ ] No
