### PR TITLE
feat: add markdown and html support

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,21 +426,21 @@ that any comment can be deleted by placing your cursor on it and pressing `dgc`.
 
 | Language   | Styles (\* = default) | Built-in annotations           |
 | ---------- | --------------------- | ------------------------------ |
-| Bash       | \*Google              | `comment`, `function`          |
-| C          | \*Doxygen             | `comment`, `function`          |
-| C++        | \*Doxygen             | `comment`, `function`          |
-| Go         | \*Godoc               | `comment`, `function`          |
+| bash       | \*Google              | `comment`, `function`          |
+| c          | \*Doxygen             | `comment`, `function`          |
+| c++ (cpp)  | \*Doxygen             | `comment`, `function`          |
+| go         | \*Godoc               | `comment`, `function`          |
 | html       | \*Codedocs            | `comment`                      |
-| JavaScript | \*JSDoc               | `comment`, `function`, `class` |
-| Java       | \*JavaDoc             | `comment`, `function`, `class` |
-| Kotlin     | \*KDoc                | `comment`, `function`, `class` |
-| Lua        | \*EmmyLua, LDoc       | `comment`, `function`          |
-| Markdown   | \*Codedocs            | `comment`                      |
-| Python     | Google, NumPy, \*reST | `comment`, `function`, `class` |
-| PHP        | \*PHPDoc              | `comment`, `function`          |
-| Ruby       | \*YARD                | `comment`, `function`          |
-| Rust       | \*RustDoc             | `comment`, `function`          |
-| TypeScript | \*TSDoc               | `comment`, `function`, `class` |
+| javascript | \*JSDoc               | `comment`, `function`, `class` |
+| java       | \*JavaDoc             | `comment`, `function`, `class` |
+| kotlin     | \*KDoc                | `comment`, `function`, `class` |
+| lua        | \*EmmyLua, LDoc       | `comment`, `function`          |
+| markdown   | \*Codedocs            | `comment`                      |
+| python     | Google, NumPy, \*reST | `comment`, `function`, `class` |
+| php        | \*PHPDoc              | `comment`, `function`          |
+| ruby       | \*YARD                | `comment`, `function`          |
+| rust       | \*RustDoc             | `comment`, `function`          |
+| typescript | \*TSDoc               | `comment`, `function`, `class` |
 
 ## Annotation examples
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,10 @@ that any comment can be deleted by placing your cursor on it and pressing `dgc`.
 
 ## Language support
 
+> [!INFO]
+> The `Codedocs` style is not an official style. It exists to provide annotations
+> for languages without native styles or to offer a custom alternative.
+
 | Language   | Styles (\* = default) | Built-in annotations           |
 | ---------- | --------------------- | ------------------------------ |
 | Bash       | \*Google              | `comment`, `function`          |
@@ -430,6 +434,7 @@ that any comment can be deleted by placing your cursor on it and pressing `dgc`.
 | Java       | \*JavaDoc             | `comment`, `function`, `class` |
 | Kotlin     | \*KDoc                | `comment`, `function`, `class` |
 | Lua        | \*EmmyLua, LDoc       | `comment`, `function`          |
+| Markdown   | \*Codedocs            | `comment`                      |
 | Python     | Google, NumPy, \*reST | `comment`, `function`, `class` |
 | PHP        | \*PHPDoc              | `comment`, `function`          |
 | Ruby       | \*YARD                | `comment`, `function`          |

--- a/README.md
+++ b/README.md
@@ -424,23 +424,23 @@ that any comment can be deleted by placing your cursor on it and pressing `dgc`.
 > The `Codedocs` style is not an official style. It exists to provide annotations
 > for languages without native styles or to offer a custom alternative.
 
-| Language   | Styles (\* = default) | Built-in annotations           |
-| ---------- | --------------------- | ------------------------------ |
-| bash       | \*Google              | `comment`, `function`          |
-| c          | \*Doxygen             | `comment`, `function`          |
-| c++ (cpp)  | \*Doxygen             | `comment`, `function`          |
-| go         | \*Godoc               | `comment`, `function`          |
-| html       | \*Codedocs            | `comment`                      |
-| javascript | \*JSDoc               | `comment`, `function`, `class` |
-| java       | \*JavaDoc             | `comment`, `function`, `class` |
-| kotlin     | \*KDoc                | `comment`, `function`, `class` |
-| lua        | \*EmmyLua, LDoc       | `comment`, `function`          |
-| markdown   | \*Codedocs            | `comment`                      |
-| python     | Google, NumPy, \*reST | `comment`, `function`, `class` |
-| php        | \*PHPDoc              | `comment`, `function`          |
-| ruby       | \*YARD                | `comment`, `function`          |
-| rust       | \*RustDoc             | `comment`, `function`          |
-| typescript | \*TSDoc               | `comment`, `function`, `class` |
+| Language   | Styles (\* = default) | Built-in annotations       |
+| ---------- | --------------------- | -------------------------- |
+| bash       | \*Google              | `comment`, `func`          |
+| c          | \*Doxygen             | `comment`, `func`          |
+| c++ (cpp)  | \*Doxygen             | `comment`, `func`          |
+| go         | \*Godoc               | `comment`, `func`          |
+| html       | \*Codedocs            | `comment`                  |
+| javascript | \*JSDoc               | `comment`, `func`, `class` |
+| java       | \*JavaDoc             | `comment`, `func`, `class` |
+| kotlin     | \*KDoc                | `comment`, `func`, `class` |
+| lua        | \*EmmyLua, LDoc       | `comment`, `func`          |
+| markdown   | \*Codedocs            | `comment`                  |
+| python     | Google, NumPy, \*reST | `comment`, `func`, `class` |
+| php        | \*PHPDoc              | `comment`, `func`          |
+| ruby       | \*YARD                | `comment`, `func`          |
+| rust       | \*RustDoc             | `comment`, `func`          |
+| typescript | \*TSDoc               | `comment`, `func`, `class` |
 
 ## Annotation examples
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ that any comment can be deleted by placing your cursor on it and pressing `dgc`.
 | C          | \*Doxygen             | `comment`, `function`          |
 | C++        | \*Doxygen             | `comment`, `function`          |
 | Go         | \*Godoc               | `comment`, `function`          |
+| html       | \*Codedocs            | `comment`                      |
 | JavaScript | \*JSDoc               | `comment`, `function`, `class` |
 | Java       | \*JavaDoc             | `comment`, `function`, `class` |
 | Kotlin     | \*KDoc                | `comment`, `function`, `class` |

--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -73,6 +73,7 @@ return {
 		lua = require "codedocs.config.languages.lua",
 		rust = require "codedocs.config.languages.rust",
 		markdown = require "codedocs.config.languages.markdown",
+		html = require "codedocs.config.languages.html",
 	},
 	aliases = {
 		sh = "bash",

--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -72,6 +72,7 @@ return {
 		php = require "codedocs.config.languages.php",
 		lua = require "codedocs.config.languages.lua",
 		rust = require "codedocs.config.languages.rust",
+		markdown = require "codedocs.config.languages.markdown",
 	},
 	aliases = {
 		sh = "bash",

--- a/lua/codedocs/config/languages/html/Codedocs.lua
+++ b/lua/codedocs/config/languages/html/Codedocs.lua
@@ -1,0 +1,16 @@
+local language_utils = require "codedocs.config.languages.utils"
+
+return {
+	comment = {
+		relative_position = "empty_target_or_above",
+		indented = false,
+		blocks = {
+			language_utils.new_section {
+				name = "title",
+				layout = {
+					"<!-- ${%snippet_tabstop_idx:description} -->",
+				},
+			},
+		},
+	},
+}

--- a/lua/codedocs/config/languages/html/init.lua
+++ b/lua/codedocs/config/languages/html/init.lua
@@ -1,0 +1,18 @@
+---@alias CodedocsHTMLStyleNames
+---| "Codedocs"
+
+---@alias CodedocsHTMLStructNames
+---| "comment"
+
+---@class CodedocsHTMLConfig: CodedocsLanguageConfig
+---@field default_style CodedocsHTMLStyleNames
+---@field styles table<CodedocsHTMLStyleNames, table<CodedocsHTMLStructNames, CodedocsAnnotationStyleOpts>>
+
+---@type CodedocsHTMLConfig
+return {
+	default_style = "Codedocs",
+	styles = {
+		Codedocs = require "codedocs.config.languages.html.Codedocs",
+	},
+	targets = {},
+}

--- a/lua/codedocs/config/languages/markdown/Codedocs.lua
+++ b/lua/codedocs/config/languages/markdown/Codedocs.lua
@@ -1,0 +1,16 @@
+local language_utils = require "codedocs.config.languages.utils"
+
+return {
+	comment = {
+		relative_position = "empty_target_or_above",
+		indented = false,
+		blocks = {
+			language_utils.new_section {
+				name = "title",
+				layout = {
+					"<!-- ${%snippet_tabstop_idx:description} -->",
+				},
+			},
+		},
+	},
+}

--- a/lua/codedocs/config/languages/markdown/init.lua
+++ b/lua/codedocs/config/languages/markdown/init.lua
@@ -1,0 +1,18 @@
+---@alias CodedocsMarkdownStyleNames
+---| "Codedocs"
+
+---@alias CodedocsMarkdownStructNames
+---| "comment"
+
+---@class CodedocsMarkdownConfig: CodedocsLanguageConfig
+---@field default_style CodedocsMarkdownStyleNames
+---@field styles table<CodedocsMarkdownStyleNames, table<CodedocsMarkdownStructNames, CodedocsAnnotationStyleOpts>>
+
+---@type CodedocsMarkdownConfig
+return {
+	default_style = "Codedocs",
+	styles = {
+		Codedocs = require "codedocs.config.languages.markdown.Codedocs",
+	},
+	targets = {},
+}

--- a/plugin/codedocs.lua
+++ b/plugin/codedocs.lua
@@ -23,8 +23,7 @@ vim.api.nvim_set_keymap(
 local function get_annotation_list()
 	local lang = vim.bo.filetype
 	local lang_stuff = require("codedocs.config").languages[lang]
-	local substyles = vim.tbl_keys(lang_stuff.styles.definitions[lang_stuff.styles.default])
-	print(vim.inspect(substyles))
+	local substyles = vim.tbl_keys(lang_stuff.styles[lang_stuff.default_style])
 	return substyles
 end
 
@@ -38,7 +37,6 @@ vim.api.nvim_create_user_command("Codedocs", function(opts)
 end, {
 	nargs = "?",
 	complete = function(arglead)
-		print(vim.inspect(get_annotation_list()))
 		return vim.tbl_filter(function(opt) return opt:find(arglead) == 1 end, get_annotation_list())
 	end,
 })

--- a/tests/defaults/annotations/annotations_spec.lua
+++ b/tests/defaults/annotations/annotations_spec.lua
@@ -2,9 +2,14 @@ package.path = package.path .. ";" .. debug.getinfo(1, "S").source:sub(2):match 
 
 local test_utils = require "tests.utils"
 local Codedocs = require "codedocs"
+local IGNORE = {}
+
+local LANGS_TO_TEST = vim.iter(require("codedocs").get_supported_langs())
+	:filter(function(v) return not vim.list_contains(IGNORE, v) end)
+	:totable()
 
 describe("Default style annotations", function()
-	for _, lang in ipairs(Codedocs.get_supported_langs()) do
+	for _, lang in ipairs(LANGS_TO_TEST) do
 		for target_name, target_cases in pairs(require("tests.defaults.annotations.test_cases." .. lang)) do
 			describe(lang .. " - " .. target_name, function()
 				for idx, target_case in ipairs(target_cases) do

--- a/tests/defaults/annotations/test_cases/html.lua
+++ b/tests/defaults/annotations/test_cases/html.lua
@@ -1,0 +1,15 @@
+return {
+	comment = {
+		{
+			structure = {
+				"",
+			},
+			cursor_pos = 1,
+			expected_annotation = {
+				Codedocs = {
+					"<!-- ${1:description} -->",
+				},
+			},
+		},
+	},
+}

--- a/tests/defaults/annotations/test_cases/markdown.lua
+++ b/tests/defaults/annotations/test_cases/markdown.lua
@@ -1,0 +1,15 @@
+return {
+	comment = {
+		{
+			structure = {
+				"",
+			},
+			cursor_pos = 1,
+			expected_annotation = {
+				Codedocs = {
+					"<!-- ${1:description} -->",
+				},
+			},
+		},
+	},
+}

--- a/tests/specs/item_extraction/item_extraction_spec.lua
+++ b/tests/specs/item_extraction/item_extraction_spec.lua
@@ -1,7 +1,12 @@
 package.path = package.path .. ";" .. debug.getinfo(1, "S").source:sub(2):match "(.*/)" .. "/tests"
 
 local test_utils = require "tests.utils"
-local LANGS_TO_TEST = require("codedocs").get_supported_langs()
+local IGNORE = {
+	"markdown",
+}
+local LANGS_TO_TEST = vim.iter(require("codedocs").get_supported_langs())
+	:filter(function(v) return not vim.list_contains(IGNORE, v) end)
+	:totable()
 
 describe("Basic item extraction", function()
 	for _, lang in ipairs(LANGS_TO_TEST) do

--- a/tests/specs/item_extraction/item_extraction_spec.lua
+++ b/tests/specs/item_extraction/item_extraction_spec.lua
@@ -3,6 +3,7 @@ package.path = package.path .. ";" .. debug.getinfo(1, "S").source:sub(2):match 
 local test_utils = require "tests.utils"
 local IGNORE = {
 	"markdown",
+	"html",
 }
 local LANGS_TO_TEST = vim.iter(require("codedocs").get_supported_langs())
 	:filter(function(v) return not vim.list_contains(IGNORE, v) end)


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

This PR adds support for both `Markdown` and `HTML` comments

## Changes

- Adds support for both `markdown` and `html`
- Fixes a bug that prevented the `Codedocs` command for detecting what targets were defined for the current language

## Breaking changes

- [ ] Yes
- [x] No
