### PR TITLE
feat: add `TOML` and `SQL` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ require("codedocs").setup({
 | ruby       | \*YARD                | `comment`, `func`          |
 | rust       | \*RustDoc             | `comment`, `func`          |
 | typescript | \*TSDoc               | `comment`, `func`, `class` |
+| toml       | \*Codedocs            | `comment`                  |
 
 ## Annotation examples
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ require("codedocs").setup({
 | php        | \*PHPDoc              | `comment`, `func`          |
 | ruby       | \*YARD                | `comment`, `func`          |
 | rust       | \*RustDoc             | `comment`, `func`          |
+| sql        | \*Codedocs            | `comment`                  |
 | typescript | \*TSDoc               | `comment`, `func`, `class` |
 | toml       | \*Codedocs            | `comment`                  |
 

--- a/lua/codedocs/config/languages/sql/init.lua
+++ b/lua/codedocs/config/languages/sql/init.lua
@@ -1,0 +1,5 @@
+return {
+	default_style = "Codedocs",
+	styles = {},
+	targets = {},
+}

--- a/lua/codedocs/config/languages/sql/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/sql/styles/Codedocs.lua
@@ -1,0 +1,16 @@
+local lang_utils = require "codedocs.config.languages.utils"
+
+return {
+	comment = {
+		relative_position = "empty_target_or_above",
+		indented = false,
+		blocks = {
+			lang_utils.new_section {
+				name = "title",
+				layout = {
+					"-- ${%snippet_tabstop_idx:description}",
+				},
+			},
+		},
+	},
+}

--- a/lua/codedocs/config/languages/toml/init.lua
+++ b/lua/codedocs/config/languages/toml/init.lua
@@ -1,0 +1,5 @@
+return {
+	default_style = "Codedocs",
+	styles = {},
+	targets = {},
+}

--- a/lua/codedocs/config/languages/toml/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/toml/styles/Codedocs.lua
@@ -1,0 +1,16 @@
+local lang_utils = require "codedocs.config.languages.utils"
+
+return {
+	comment = {
+		relative_position = "empty_target_or_above",
+		indented = false,
+		blocks = {
+			lang_utils.new_section {
+				name = "title",
+				layout = {
+					"# ${%snippet_tabstop_idx:description}",
+				},
+			},
+		},
+	},
+}

--- a/tests/annotations/defaults/test_cases/sql.lua
+++ b/tests/annotations/defaults/test_cases/sql.lua
@@ -1,0 +1,15 @@
+return {
+	comment = {
+		{
+			structure = {
+				"",
+			},
+			cursor_pos = 1,
+			expected_annotation = {
+				Codedocs = {
+					"-- ${1:description}",
+				},
+			},
+		},
+	},
+}

--- a/tests/annotations/defaults/test_cases/toml.lua
+++ b/tests/annotations/defaults/test_cases/toml.lua
@@ -1,0 +1,15 @@
+return {
+	comment = {
+		{
+			structure = {
+				"",
+			},
+			cursor_pos = 1,
+			expected_annotation = {
+				Codedocs = {
+					"# ${1:description}",
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

This PR adds support for both `TOML` and `SQL`

## Changes

- Adds support for `TOML` and `SQL`

## Breaking changes

- [ ] Yes
- [x] No
