### PR TITLE
feat: add `shebang` support to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,25 +553,25 @@ require("codedocs").setup {
 > The `Codedocs` style is not an official style. It exists to provide annotations
 > for languages without native styles or to offer a custom alternative.
 
-| Language   | Styles (\* = default) | Built-in annotations       |
-| ---------- | --------------------- | -------------------------- |
-| bash       | \*Google              | `comment`, `func`          |
-| c          | \*Doxygen             | `comment`, `func`          |
-| c++ (cpp)  | \*Doxygen             | `comment`, `func`          |
-| go         | \*Godoc               | `comment`, `func`          |
-| html       | \*Codedocs            | `comment`                  |
-| javascript | \*JSDoc               | `comment`, `func`, `class` |
-| java       | \*JavaDoc             | `comment`, `func`, `class` |
-| kotlin     | \*KDoc                | `comment`, `func`, `class` |
-| lua        | \*EmmyLua, LDoc       | `comment`, `func`          |
-| markdown   | \*Codedocs            | `comment`                  |
-| python     | Google, NumPy, \*reST | `comment`, `func`, `class` |
-| php        | \*PHPDoc              | `comment`, `func`          |
-| ruby       | \*YARD                | `comment`, `func`          |
-| rust       | \*RustDoc             | `comment`, `func`          |
-| sql        | \*Codedocs            | `comment`                  |
-| typescript | \*TSDoc               | `comment`, `func`, `class` |
-| toml       | \*Codedocs            | `comment`                  |
+| Language   | Styles (\* = default) | Built-in annotations         |
+| ---------- | --------------------- | ---------------------------- |
+| bash       | \*Google              | `comment`, `func`, `shebang` |
+| c          | \*Doxygen             | `comment`, `func`            |
+| c++ (cpp)  | \*Doxygen             | `comment`, `func`            |
+| go         | \*Godoc               | `comment`, `func`            |
+| html       | \*Codedocs            | `comment`                    |
+| javascript | \*JSDoc               | `comment`, `func`, `class`   |
+| java       | \*JavaDoc             | `comment`, `func`, `class`   |
+| kotlin     | \*KDoc                | `comment`, `func`, `class`   |
+| lua        | \*EmmyLua, LDoc       | `comment`, `func`            |
+| markdown   | \*Codedocs            | `comment`                    |
+| python     | Google, NumPy, \*reST | `comment`, `func`, `class`   |
+| php        | \*PHPDoc              | `comment`, `func`            |
+| ruby       | \*YARD                | `comment`, `func`            |
+| rust       | \*RustDoc             | `comment`, `func`            |
+| sql        | \*Codedocs            | `comment`                    |
+| typescript | \*TSDoc               | `comment`, `func`, `class`   |
+| toml       | \*Codedocs            | `comment`                    |
 
 ## Annotation examples
 

--- a/lua/codedocs/config/languages/bash/styles/Google.lua
+++ b/lua/codedocs/config/languages/bash/styles/Google.lua
@@ -13,6 +13,18 @@ return {
 			},
 		},
 	},
+	shebang = {
+		relative_position = "empty_target_or_above",
+		indented = false,
+		blocks = {
+			language_utils.new_section {
+				name = "title",
+				layout = {
+					"#${%snippet_tabstop_idx:!/usr/bin/env bash}",
+				},
+			},
+		},
+	},
 	func = {
 		relative_position = "above",
 		indented = false,

--- a/tests/annotations/defaults/test_cases/bash.lua
+++ b/tests/annotations/defaults/test_cases/bash.lua
@@ -12,6 +12,19 @@ return {
 			},
 		},
 	},
+	shebang = {
+		{
+			structure = {
+				"",
+			},
+			cursor_pos = 1,
+			expected_annotation = {
+				Google = {
+					"#${1:!/usr/bin/env bash}",
+				},
+			},
+		},
+	},
 	func = {
 		{
 			structure = {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

This PR adds support for the `shebang` annotation in Bash

## Changes

- `shebang` is now a supported annotation for Bash

## Breaking changes

- [ ] Yes
- [x] No
