### PR TITLE
feat: add `phptag` support to PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ require("codedocs").setup {
 | lua        | \*EmmyLua, LDoc       | `comment`, `func`            |
 | markdown   | \*Codedocs            | `comment`                    |
 | python     | Google, NumPy, \*reST | `comment`, `func`, `class`   |
-| php        | \*PHPDoc              | `comment`, `func`            |
+| php        | \*PHPDoc              | `comment`, `func`, `phptag`  |
 | ruby       | \*YARD                | `comment`, `func`            |
 | rust       | \*RustDoc             | `comment`, `func`            |
 | sql        | \*Codedocs            | `comment`                    |

--- a/lua/codedocs/config/languages/php/styles/PHPDoc.lua
+++ b/lua/codedocs/config/languages/php/styles/PHPDoc.lua
@@ -13,6 +13,19 @@ return {
 			},
 		},
 	},
+	phptag = {
+		relative_position = "empty_target_or_above",
+		indent = false,
+		blocks = {
+			lang_utils.new_section {
+				name = "title",
+				layout = {
+					"<?php",
+					"${%snippet_tabstop_idx:code}",
+				},
+			},
+		},
+	},
 	func = {
 		relative_position = "above",
 		indent = false,

--- a/tests/annotations/defaults/test_cases/php.lua
+++ b/tests/annotations/defaults/test_cases/php.lua
@@ -13,6 +13,18 @@ return {
 			},
 		},
 	},
+	phptag = {
+		{
+			structure = { "" },
+			cursor_pos = 1,
+			expected_annotation = {
+				PHPDoc = {
+					"<?php",
+					"${1:code}",
+				},
+			},
+		},
+	},
 	func = {
 		{
 			structure = {


### PR DESCRIPTION

## Description

This PR adds support for the `phptag` annotation in PHP

## Changes

- Adds support for the `phptag` annotation in PHP

## Breaking changes

- [ ] Yes
- [x] No
