### PR TITLE
fix: only require `targets` directory files if `targets/` exists

### DIFF
--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -75,6 +75,10 @@ end
 
 local function construct_table_from_files(lang_name, dir_name)
 	local path = languages_base .. "/" .. lang_name .. "/" .. dir_name
+
+	local stat = vim.loop.fs_stat(path)
+	if not stat or stat.type ~= "directory" then return {} end
+
 	return vim.iter(read_lua_file_names(path)):fold({}, function(targets_acc, file_name)
 		targets_acc[file_name] = require(("codedocs.config.languages.%s.%s.%s"):format(lang_name, dir_name, file_name))
 		return targets_acc


### PR DESCRIPTION

<!-- markdownlint-disable first-line-heading -->

## Description

The plugin works as intended but a warning pops up at startup because in `config/init.lua` we try to require all files in the `targets` directory for all languages. 
## Changes

- Only read the directory files if the directory itself exists

## Breaking changes

- [ ] Yes
- [x] No
