### PR TITLE
fix: only write `tags` file if dir is writable

### DIFF
--- a/plugin/codedocs.lua
+++ b/plugin/codedocs.lua
@@ -3,13 +3,12 @@ if curr_file_path:sub(1, 1) == "@" then curr_file_path = curr_file_path:sub(2) e
 
 local plugin_dir = vim.fn.fnamemodify(curr_file_path, ":p:h")
 
--- Load help tags
 vim.api.nvim_create_autocmd("VimEnter", {
 	callback = function()
 		local doc_dir = vim.fn.fnamemodify(plugin_dir .. "/../doc", ":p")
-		if vim.fn.isdirectory(doc_dir) == 1 then
-			local load_help_tag_cmd = "helptags " .. vim.fn.fnameescape(doc_dir)
-			vim.cmd(load_help_tag_cmd)
+
+		if vim.fn.isdirectory(doc_dir) == 1 and vim.fn.filewritable(doc_dir) == 2 then
+			pcall(vim.cmd, "silent helptags " .. vim.fn.fnameescape(doc_dir))
 		end
 	end,
 })


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Attempting to create the `tags` file in a read-only directory will throw errors

## Changes

- The `tags` file is only created if the target directory is writable

## Breaking changes

- [ ] Yes
- [x] No
