### PR TITLE
test: add test for Treesitter `comment` annotation

### DIFF
--- a/tests/annotations/defaults/cases/treesitter/comment/empty/metadata.lua
+++ b/tests/annotations/defaults/cases/treesitter/comment/empty/metadata.lua
@@ -1,0 +1,5 @@
+return {
+	cursor = {
+		row = 1,
+	},
+}

--- a/tests/annotations/defaults/cases/treesitter/comment/empty/output/Codedocs
+++ b/tests/annotations/defaults/cases/treesitter/comment/empty/output/Codedocs
@@ -1,0 +1,1 @@
+; ${1:description}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Adds a test to validate that the Treesitter `comment` annotation works properly

## Breaking changes

- [ ] Yes
- [x] No
