### PR TITLE
refactor!: replace `aliases` opt with lang inline `filetypes` opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,6 @@ require("codedocs").setup {
             },
         },
     },
-    aliases = {
-        sh = "bash"
-    }
 }
 ```
 

--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -130,8 +130,4 @@ return {
 			},
 		},
 	},
-	aliases = {
-		sh = "bash",
-		query = "treesitter",
-	},
 }

--- a/lua/codedocs/config/languages/bash/init.lua
+++ b/lua/codedocs/config/languages/bash/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "Google",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"sh",
+	},
 }

--- a/lua/codedocs/config/languages/c/init.lua
+++ b/lua/codedocs/config/languages/c/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "Doxygen",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"c",
+	},
 }

--- a/lua/codedocs/config/languages/cpp/init.lua
+++ b/lua/codedocs/config/languages/cpp/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "Doxygen",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"cpp",
+	},
 }

--- a/lua/codedocs/config/languages/gdscript/init.lua
+++ b/lua/codedocs/config/languages/gdscript/init.lua
@@ -2,4 +2,7 @@ return {
 	default_style = "Codedocs",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"gdscript",
+	},
 }

--- a/lua/codedocs/config/languages/go/init.lua
+++ b/lua/codedocs/config/languages/go/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "Godoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"go",
+	},
 }

--- a/lua/codedocs/config/languages/html/init.lua
+++ b/lua/codedocs/config/languages/html/init.lua
@@ -13,4 +13,7 @@ return {
 	default_style = "Codedocs",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"html",
+	},
 }

--- a/lua/codedocs/config/languages/java/init.lua
+++ b/lua/codedocs/config/languages/java/init.lua
@@ -15,4 +15,7 @@ return {
 	default_style = "JavaDoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"java",
+	},
 }

--- a/lua/codedocs/config/languages/javascript/init.lua
+++ b/lua/codedocs/config/languages/javascript/init.lua
@@ -15,4 +15,7 @@ return {
 	default_style = "JSDoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"javascript",
+	},
 }

--- a/lua/codedocs/config/languages/kotlin/init.lua
+++ b/lua/codedocs/config/languages/kotlin/init.lua
@@ -15,4 +15,7 @@ return {
 	default_style = "KDoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"kotlin",
+	},
 }

--- a/lua/codedocs/config/languages/lua/init.lua
+++ b/lua/codedocs/config/languages/lua/init.lua
@@ -15,4 +15,7 @@ return {
 	default_style = "EmmyLua",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"lua",
+	},
 }

--- a/lua/codedocs/config/languages/markdown/init.lua
+++ b/lua/codedocs/config/languages/markdown/init.lua
@@ -13,4 +13,7 @@ return {
 	default_style = "Codedocs",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"markdown",
+	},
 }

--- a/lua/codedocs/config/languages/php/init.lua
+++ b/lua/codedocs/config/languages/php/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "PHPDoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"php",
+	},
 }

--- a/lua/codedocs/config/languages/python/init.lua
+++ b/lua/codedocs/config/languages/python/init.lua
@@ -17,4 +17,7 @@ return {
 	default_style = "reST",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"python",
+	},
 }

--- a/lua/codedocs/config/languages/ruby/init.lua
+++ b/lua/codedocs/config/languages/ruby/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "YARD",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"ruby",
+	},
 }

--- a/lua/codedocs/config/languages/rust/init.lua
+++ b/lua/codedocs/config/languages/rust/init.lua
@@ -14,4 +14,7 @@ return {
 	default_style = "RustDoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"rust",
+	},
 }

--- a/lua/codedocs/config/languages/sql/init.lua
+++ b/lua/codedocs/config/languages/sql/init.lua
@@ -2,4 +2,7 @@ return {
 	default_style = "Codedocs",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"sql",
+	},
 }

--- a/lua/codedocs/config/languages/toml/init.lua
+++ b/lua/codedocs/config/languages/toml/init.lua
@@ -2,4 +2,7 @@ return {
 	default_style = "Codedocs",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"toml",
+	},
 }

--- a/lua/codedocs/config/languages/treesitter/init.lua
+++ b/lua/codedocs/config/languages/treesitter/init.lua
@@ -2,4 +2,7 @@ return {
 	default_style = "Codedocs",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"query",
+	},
 }

--- a/lua/codedocs/config/languages/typescript/init.lua
+++ b/lua/codedocs/config/languages/typescript/init.lua
@@ -15,4 +15,7 @@ return {
 	default_style = "TSDoc",
 	styles = {},
 	targets = {},
+	filetypes = {
+		"typescript",
+	},
 }

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -38,8 +38,19 @@ local function _write_to_buffer(annotation_lines, row, placement)
 end
 
 local function _determine_lang_name()
-	local filetype = vim.bo.filetype
-	return require("codedocs.config").aliases[filetype] or filetype
+	if not Codedocs._filetypes_map then
+		local langs_config = require("codedocs.config").languages
+		local filetypes_map = {}
+		for lang_name, opts in pairs(langs_config) do
+			for _, filetype_name in ipairs(opts.filetypes) do
+				filetypes_map[filetype_name] = lang_name
+			end
+		end
+
+		Codedocs._filetypes_map = filetypes_map
+	end
+
+	return Codedocs._filetypes_map[vim.bo.filetype]
 end
 
 function Codedocs.get_supported_langs() return vim.tbl_keys(require("codedocs.config").languages) end
@@ -80,9 +91,6 @@ Codedocs.get_target_identifiers = require("codedocs.item_extractor").get_target_
 local function validate_config(config)
 	vim.validate {
 		["config.debug"] = { config.debug, "boolean" },
-	}
-	vim.validate {
-		["config.aliases"] = { config.aliases, "table" },
 	}
 	vim.validate {
 		["config.languages"] = { config.languages, "table" },


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Replaces the `aliases` option with a language-specific `filetypes` option that defines what filetype names correspond to that language.

## Breaking changes

- [x] Yes
- [ ] No
