### PR TITLE
feat: expand styles opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ require("codedocs").setup {
             styles = {
                 -- Style name
                 reST = {
+                    default_annot = "comment",
                     annots = { --- See the `annotations` section below
                         func = {}, -- `func` annotation
                         class = {}, -- `class` annotation

--- a/README.md
+++ b/README.md
@@ -221,10 +221,11 @@ require("codedocs").setup {
             styles = {
                 -- Style name
                 reST = {
-                    --- See the `annotations` section below
-                    func = {}, -- `func` annotation
-                    class = {}, -- `class` annotation
-                    comment = {} -- `comment` annotation
+                    annots = { --- See the `annotations` section below
+                        func = {}, -- `func` annotation
+                        class = {}, -- `class` annotation
+                        comment = {} -- `comment` annotation
+                    }
                 },
             },
             targets = {

--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -93,8 +93,8 @@ return {
 
 		base_lang_config.styles = _build_dir_tbl(name, "styles")
 
-		for _, annotations in pairs(base_lang_config.styles) do
-			for _, annotation_opts in pairs(annotations) do
+		for _, style_opts in pairs(base_lang_config.styles) do
+			for _, annotation_opts in pairs(style_opts.annots) do
 				annotation_opts.blocks = lang_utils.new_blocks_list(annotation_opts.blocks)
 			end
 		end

--- a/lua/codedocs/config/languages/bash/styles/Google.lua
+++ b/lua/codedocs/config/languages/bash/styles/Google.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/bash/styles/Google.lua
+++ b/lua/codedocs/config/languages/bash/styles/Google.lua
@@ -1,55 +1,57 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	shebang = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"#${%snip_idx:!/usr/bin/env bash}",
+		shebang = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"#${%snip_idx:!/usr/bin/env bash}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"#######################################",
-					"# ${%snip_idx:title}",
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
+					layout = {
+						"#######################################",
+						"# ${%snip_idx:title}",
+					},
 				},
-			},
-			{
-				name = "globals",
-				layout = { "# Globals:" },
-				items = { layout = { "#   %item_name" } },
-			},
-			{
-				name = "parameters",
-				layout = { "# Arguments:" },
-				items = { layout = { "#   ${%snip_idx:description}" } },
-			},
-			{
-				name = "returns",
-				layout = { "Returns:" },
-				items = { layout = { "%item_type:" } },
-			},
-			{
-				name = "footer",
-				layout = {
-					"#######################################",
+				{
+					name = "globals",
+					layout = { "# Globals:" },
+					items = { layout = { "#   %item_name" } },
+				},
+				{
+					name = "parameters",
+					layout = { "# Arguments:" },
+					items = { layout = { "#   ${%snip_idx:description}" } },
+				},
+				{
+					name = "returns",
+					layout = { "Returns:" },
+					items = { layout = { "%item_type:" } },
+				},
+				{
+					name = "footer",
+					layout = {
+						"#######################################",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/c/styles/Doxygen.lua
+++ b/lua/codedocs/config/languages/c/styles/Doxygen.lua
@@ -1,67 +1,69 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = " *",
-					},
-					returns = {
-						enabled = true,
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = " *",
-					},
-				},
-				items = {
-					layout = { " * @param %item_name ${%snip_idx:description}" },
-					insert_gap_between = { text = " *" },
-				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @return ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					insert_gap_between = { text = " *" },
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = " *",
+						},
+						returns = {
+							enabled = true,
+							text = " *",
+						},
+					},
 				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = { " * @param %item_name ${%snip_idx:description}" },
+						insert_gap_between = { text = " *" },
+					},
+				},
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @return ${%snip_idx:description}",
+						},
+						insert_gap_between = { text = " *" },
+					},
+				},
+				{
+					name = "footer",
+					layout = {
+						" */",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/c/styles/Doxygen.lua
+++ b/lua/codedocs/config/languages/c/styles/Doxygen.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/cpp/styles/Doxygen.lua
+++ b/lua/codedocs/config/languages/cpp/styles/Doxygen.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/cpp/styles/Doxygen.lua
+++ b/lua/codedocs/config/languages/cpp/styles/Doxygen.lua
@@ -1,69 +1,71 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						text = " *",
-						enabled = true,
-					},
-					returns = {
-						text = " *",
-						enabled = true,
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = " *",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @param %item_name ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					insert_gap_between = { text = " *" },
-				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
+					gap_before = {
+						parameters = {
+							text = " *",
+							enabled = true,
+						},
+						returns = {
+							text = " *",
+							enabled = true,
+						},
 					},
 				},
-				items = {
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @param %item_name ${%snip_idx:description}",
+						},
+						insert_gap_between = { text = " *" },
+					},
+				},
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @return ${%snip_idx:description}",
+						},
+						insert_gap_between = { text = " *" },
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						" * @return ${%snip_idx:description}",
+						" */",
 					},
-					insert_gap_between = { text = " *" },
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/gdscript/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/gdscript/styles/Codedocs.lua
@@ -1,44 +1,46 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	export = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"@export ${%snip_idx:property}",
+		export = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"@export ${%snip_idx:property}",
+					},
 				},
 			},
 		},
-	},
-	onready = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"@onready ${%snip_idx:property}",
+		onready = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"@onready ${%snip_idx:property}",
+					},
 				},
 			},
 		},
-	},
-	warning_ignore = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					'@warning_ignore("${%snip_idx:warning}")',
+		warning_ignore = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						'@warning_ignore("${%snip_idx:warning}")',
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/gdscript/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/gdscript/styles/Codedocs.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/go/styles/Godoc.lua
+++ b/lua/codedocs/config/languages/go/styles/Godoc.lua
@@ -1,43 +1,45 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						text = "//",
-						enabled = true,
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:title}",
+					},
+					gap_before = {
+						parameters = {
+							text = "//",
+							enabled = true,
+						},
 					},
 				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = "//",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = "//",
+						},
 					},
+					items = { insert_gap_between = { text = "//" } },
 				},
-				items = { insert_gap_between = { text = "//" } },
-			},
-			{
-				name = "returns",
-				items = { insert_gap_between = { text = "//" } },
+				{
+					name = "returns",
+					items = { insert_gap_between = { text = "//" } },
+				},
 			},
 		},
 	},

--- a/lua/codedocs/config/languages/go/styles/Godoc.lua
+++ b/lua/codedocs/config/languages/go/styles/Godoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/html/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/html/styles/Codedocs.lua
@@ -1,11 +1,13 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"<!-- ${%snip_idx:description} -->",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"<!-- ${%snip_idx:description} -->",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/html/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/html/styles/Codedocs.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/java/styles/JavaDoc.lua
+++ b/lua/codedocs/config/languages/java/styles/JavaDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/java/styles/JavaDoc.lua
+++ b/lua/codedocs/config/languages/java/styles/JavaDoc.lua
@@ -1,108 +1,110 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						text = " *",
-						enabled = false,
+		class = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
+					layout = {
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					footer = {
-						text = " *",
-						enabled = false,
-					},
-				},
-			},
-			{
-				name = "attributes",
-				layout = { " * Attributes:" },
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
+					gap_before = {
+						attributes = {
+							text = " *",
+							enabled = false,
+						},
+						footer = {
+							text = " *",
+							enabled = false,
+						},
 					},
 				},
-				items = { layout = { "// %item_name" }, insert_gap_between = { text = " *" } },
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
+				{
+					name = "attributes",
+					layout = { " * Attributes:" },
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = { layout = { "// %item_name" }, insert_gap_between = { text = " *" } },
+				},
+				{
+					name = "footer",
+					layout = {
+						" */",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = " *",
-					},
-					returns = {
-						enabled = true,
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						text = " *",
-						enabled = false,
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @param %item_name ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					insert_gap_between = { text = " *" },
-				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = " *",
+						},
+						returns = {
+							enabled = true,
+							text = " *",
+						},
 					},
 				},
-				items = {
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							text = " *",
+							enabled = false,
+						},
+					},
+					items = {
+						layout = {
+							" * @param %item_name ${%snip_idx:description}",
+						},
+						insert_gap_between = { text = " *" },
+					},
+				},
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @return ${%snip_idx:description}",
+						},
+						insert_gap_between = { text = " *" },
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						" * @return ${%snip_idx:description}",
+						" */",
 					},
-					insert_gap_between = { text = " *" },
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/javascript/styles/JSDoc.lua
+++ b/lua/codedocs/config/languages/javascript/styles/JSDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/javascript/styles/JSDoc.lua
+++ b/lua/codedocs/config/languages/javascript/styles/JSDoc.lua
@@ -1,114 +1,116 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						text = " *",
-						enabled = true,
-					},
-				},
-			},
-			{
-				name = "attributes",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
-					},
-				},
-				items = {
+		class = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @property {%item_type} %item_name ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = " *",
+					gap_before = {
+						attributes = {
+							text = " *",
+							enabled = true,
+						},
 					},
 				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
+				{
+					name = "attributes",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @property {%item_type} %item_name ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
+					},
+				},
+				{
+					name = "footer",
+					layout = {
+						" */",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"/**",
-					" * ${%snip_idx:description}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = " *",
-					},
-					returns = {
-						enabled = true,
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = " *",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "title",
 					layout = {
-						" * @param {${%snip_idx:type}} %item_name ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:description}",
 					},
-					insert_gap_between = {
-						text = " *",
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = " *",
+						},
+						returns = {
+							enabled = true,
+							text = " *",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @param {${%snip_idx:type}} %item_name ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
 					},
 				},
-				items = {
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @returns {${%snip_idx:type}} ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						" * @returns {${%snip_idx:type}} ${%snip_idx:description}",
+						" */",
 					},
-					insert_gap_between = {
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/kotlin/styles/KDoc.lua
+++ b/lua/codedocs/config/languages/kotlin/styles/KDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/kotlin/styles/KDoc.lua
+++ b/lua/codedocs/config/languages/kotlin/styles/KDoc.lua
@@ -1,107 +1,109 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						enabled = true,
-						text = " *",
+		class = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
+					layout = {
+						"/**",
+						" * ${%snip_idx:title}",
+					},
+					gap_before = {
+						attributes = {
+							enabled = true,
+							text = " *",
+						},
 					},
 				},
-			},
-			{
-				name = "attributes",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
+				{
+					name = "attributes",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
 					},
+					items = { insert_gap_between = { text = " *" } },
 				},
-				items = { insert_gap_between = { text = " *" } },
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
+				{
+					name = "footer",
+					layout = {
+						" */",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = " *",
-					},
-					returns = {
-						enabled = true,
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = " *",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @param %item_name ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = " *",
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = " *",
+						},
+						returns = {
+							enabled = true,
+							text = " *",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = " *",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @param %item_name ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
 					},
 				},
-				items = {
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = " *",
+						},
+					},
+					items = {
+						layout = {
+							" * @return ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						" * @return ${%snip_idx:description}",
+						" */",
 					},
-					insert_gap_between = {
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/lua/styles/EmmyLua.lua
+++ b/lua/codedocs/config/languages/lua/styles/EmmyLua.lua
@@ -1,59 +1,61 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"---${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"---${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"---${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = false,
-						text = "---",
-					},
-					returns = {
-						enabled = false,
-						text = "---",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = "---",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "title",
 					layout = {
-						"---@param %item_name ${%snip_idx:type} ${%snip_idx:description}",
+						"---${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = "---",
+					gap_before = {
+						parameters = {
+							enabled = false,
+							text = "---",
+						},
+						returns = {
+							enabled = false,
+							text = "---",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				items = {
-					layout = {
-						"---@return ${%snip_idx:type} ${%snip_idx:description}",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = "---",
+						},
 					},
-					insert_gap_between = {
-						text = "---",
+					items = {
+						layout = {
+							"---@param %item_name ${%snip_idx:type} ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "---",
+						},
+					},
+				},
+				{
+					name = "returns",
+					items = {
+						layout = {
+							"---@return ${%snip_idx:type} ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "---",
+						},
 					},
 				},
 			},

--- a/lua/codedocs/config/languages/lua/styles/EmmyLua.lua
+++ b/lua/codedocs/config/languages/lua/styles/EmmyLua.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/lua/styles/LDoc.lua
+++ b/lua/codedocs/config/languages/lua/styles/LDoc.lua
@@ -1,59 +1,61 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"-- ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"-- ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"--- ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = false,
-						text = "--",
-					},
-					returns = {
-						enabled = false,
-						text = "--",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = "--",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "title",
 					layout = {
-						"-- @param %item_name ${%snip_idx:type} ${%snip_idx:description}",
+						"--- ${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = "--",
+					gap_before = {
+						parameters = {
+							enabled = false,
+							text = "--",
+						},
+						returns = {
+							enabled = false,
+							text = "--",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				items = {
-					layout = {
-						"-- @return ${%snip_idx:type} ${%snip_idx:description}",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = "--",
+						},
 					},
-					insert_gap_between = {
-						text = "--",
+					items = {
+						layout = {
+							"-- @param %item_name ${%snip_idx:type} ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "--",
+						},
+					},
+				},
+				{
+					name = "returns",
+					items = {
+						layout = {
+							"-- @return ${%snip_idx:type} ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "--",
+						},
 					},
 				},
 			},

--- a/lua/codedocs/config/languages/lua/styles/LDoc.lua
+++ b/lua/codedocs/config/languages/lua/styles/LDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/markdown/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/markdown/styles/Codedocs.lua
@@ -1,11 +1,13 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"<!-- ${%snip_idx:description} -->",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"<!-- ${%snip_idx:description} -->",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/markdown/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/markdown/styles/Codedocs.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/php/styles/PHPDoc.lua
+++ b/lua/codedocs/config/languages/php/styles/PHPDoc.lua
@@ -1,85 +1,87 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	phptag = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"<?php",
-					"${%snip_idx:code}",
+		phptag = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"<?php",
+						"${%snip_idx:code}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = " *",
-					},
-					returns = {
-						enabled = true,
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						text = " *",
-						enabled = false,
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @param ${%snip_idx:%item_type} \\$%item_name ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = " *",
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = " *",
+						},
+						returns = {
+							enabled = true,
+							text = " *",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						text = " *",
-						enabled = false,
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							text = " *",
+							enabled = false,
+						},
+					},
+					items = {
+						layout = {
+							" * @param ${%snip_idx:%item_type} \\$%item_name ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
 					},
 				},
-				items = {
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							text = " *",
+							enabled = false,
+						},
+					},
+					items = {
+						layout = {
+							" * @return ${%snip_idx:%item_type} ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						" * @return ${%snip_idx:%item_type} ${%snip_idx:description}",
+						" */",
 					},
-					insert_gap_between = {
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/php/styles/PHPDoc.lua
+++ b/lua/codedocs/config/languages/php/styles/PHPDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/python/styles/Google.lua
+++ b/lua/codedocs/config/languages/python/styles/Google.lua
@@ -1,111 +1,113 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "below",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					'%>"""',
-					"%>${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						enabled = true,
-						text = "",
-					},
-				},
-			},
-			{
-				name = "attributes",
-				layout = { "%>Attributes:" },
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = "",
-					},
-				},
-				items = {
+		class = {
+			placement = "below",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						"%>%item_name (%item_type): ${%snip_idx:description}",
+						'%>"""',
+						"%>${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = "",
+					gap_before = {
+						attributes = {
+							enabled = true,
+							text = "",
+						},
 					},
 				},
-			},
-			{
-				name = "footer",
-				layout = {
-					'%>"""',
+				{
+					name = "attributes",
+					layout = { "%>Attributes:" },
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>%item_name (%item_type): ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "",
+						},
+					},
+				},
+				{
+					name = "footer",
+					layout = {
+						'%>"""',
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "below",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					'%>"""',
-					"%>${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = "",
-					},
-					returns = {
-						enabled = true,
-						text = "",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				layout = { "%>Args:" },
-				gap_before = {
-					returns = {
-						enabled = true,
-						text = "",
-					},
-				},
-				items = {
+		func = {
+			placement = "below",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						"%>%>%item_name (${%snip_idx:%item_type}): ${%snip_idx:description}",
+						'%>"""',
+						"%>${%snip_idx:title}",
+					},
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = "",
+						},
+						returns = {
+							enabled = true,
+							text = "",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				layout = { "%>Returns:" },
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = "",
+				{
+					name = "parameters",
+					layout = { "%>Args:" },
+					gap_before = {
+						returns = {
+							enabled = true,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>%>%item_name (${%snip_idx:%item_type}): ${%snip_idx:description}",
+						},
 					},
 				},
-				items = {
+				{
+					name = "returns",
+					layout = { "%>Returns:" },
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>%>${%snip_idx:%item_type}: ${%snip_idx:description}",
+						},
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						"%>%>${%snip_idx:%item_type}: ${%snip_idx:description}",
+						'%>"""',
 					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					'%>"""',
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/python/styles/Google.lua
+++ b/lua/codedocs/config/languages/python/styles/Google.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/python/styles/NumPy.lua
+++ b/lua/codedocs/config/languages/python/styles/NumPy.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/python/styles/NumPy.lua
+++ b/lua/codedocs/config/languages/python/styles/NumPy.lua
@@ -1,111 +1,113 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "below",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					'%>"""',
-					"%>${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						text = "",
-						enabled = true,
-					},
-				},
-			},
-			{
-				name = "attributes",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = "",
-					},
-				},
-				layout = { "%>Attributes:", "%>___________" },
-				items = {
+		class = {
+			placement = "below",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						"%>%item_name : ${%snip_idx:%item_type}",
-						"%>	${%snip_idx:description}",
+						'%>"""',
+						"%>${%snip_idx:title}",
+					},
+					gap_before = {
+						attributes = {
+							text = "",
+							enabled = true,
+						},
 					},
 				},
-			},
-			{
-				name = "footer",
-				layout = {
-					'%>"""',
+				{
+					name = "attributes",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = "",
+						},
+					},
+					layout = { "%>Attributes:", "%>___________" },
+					items = {
+						layout = {
+							"%>%item_name : ${%snip_idx:%item_type}",
+							"%>	${%snip_idx:description}",
+						},
+					},
+				},
+				{
+					name = "footer",
+					layout = {
+						'%>"""',
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "below",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					'%>"""',
-					"%>${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = "",
-					},
-					returns = {
-						enabled = true,
-						text = "",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				layout = { "%>Parameters", "%>----------" },
-				gap_before = {
-					returns = {
-						enabled = true,
-						text = "",
-					},
-				},
-				items = {
+		func = {
+			placement = "below",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						"%>%item_name: ${%snip_idx:%item_type}",
-						"%>	${%snip_idx:description}",
+						'%>"""',
+						"%>${%snip_idx:title}",
+					},
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = "",
+						},
+						returns = {
+							enabled = true,
+							text = "",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				layout = { "%>Returns", "%>-------" },
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = "",
+				{
+					name = "parameters",
+					layout = { "%>Parameters", "%>----------" },
+					gap_before = {
+						returns = {
+							enabled = true,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>%item_name: ${%snip_idx:%item_type}",
+							"%>	${%snip_idx:description}",
+						},
 					},
 				},
-				items = {
+				{
+					name = "returns",
+					layout = { "%>Returns", "%>-------" },
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>${%snip_idx:%item_type}",
+							"%>	${%snip_idx:description}",
+						},
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						"%>${%snip_idx:%item_type}",
-						"%>	${%snip_idx:description}",
+						'%>"""',
 					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					'%>"""',
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/python/styles/reST.lua
+++ b/lua/codedocs/config/languages/python/styles/reST.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/python/styles/reST.lua
+++ b/lua/codedocs/config/languages/python/styles/reST.lua
@@ -1,108 +1,110 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "below",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					'%>"""',
-					"%>${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						text = "",
-						enabled = true,
-					},
-				},
-			},
-			{
-				name = "attributes",
-				gap_before = {
-					footer = {
-						text = "",
-						enabled = true,
-					},
-				},
-				items = {
+		class = {
+			placement = "below",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						"%>:var %item_name: ${%snip_idx:description}",
-						"%>:vartype %item_name: ${%snip_idx:%item_type}",
+						'%>"""',
+						"%>${%snip_idx:title}",
+					},
+					gap_before = {
+						attributes = {
+							text = "",
+							enabled = true,
+						},
 					},
 				},
-			},
-			{
-				name = "footer",
-				layout = {
-					'%>"""',
+				{
+					name = "attributes",
+					gap_before = {
+						footer = {
+							text = "",
+							enabled = true,
+						},
+					},
+					items = {
+						layout = {
+							"%>:var %item_name: ${%snip_idx:description}",
+							"%>:vartype %item_name: ${%snip_idx:%item_type}",
+						},
+					},
+				},
+				{
+					name = "footer",
+					layout = {
+						'%>"""',
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "below",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					'%>"""',
-					"%>${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = "",
-					},
-					returns = {
-						enabled = true,
-						text = "",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = "",
-					},
-				},
-				items = {
+		func = {
+			placement = "below",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						"%>:param %item_name: ${%snip_idx:description}",
-						"%>:type %item_name: ${%snip_idx:%item_type}",
+						'%>"""',
+						"%>${%snip_idx:title}",
+					},
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = "",
+						},
+						returns = {
+							enabled = true,
+							text = "",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						enabled = false,
-						text = "",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>:param %item_name: ${%snip_idx:description}",
+							"%>:type %item_name: ${%snip_idx:%item_type}",
+						},
 					},
 				},
-				items = {
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							enabled = false,
+							text = "",
+						},
+					},
+					items = {
+						layout = {
+							"%>:return: ${%snip_idx:description}",
+							"%>:rtype: ${%snip_idx:%item_type}",
+						},
+					},
+				},
+				{
+					name = "footer",
 					layout = {
-						"%>:return: ${%snip_idx:description}",
-						"%>:rtype: ${%snip_idx:%item_type}",
+						'%>"""',
 					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					'%>"""',
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/ruby/styles/YARD.lua
+++ b/lua/codedocs/config/languages/ruby/styles/YARD.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/ruby/styles/YARD.lua
+++ b/lua/codedocs/config/languages/ruby/styles/YARD.lua
@@ -1,59 +1,61 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = "#",
-					},
-					returns = {
-						enabled = true,
-						text = "#",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						enabled = false,
-						text = "#",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "title",
 					layout = {
-						"# @param %item_name [${%snip_idx:type}] ${%snip_idx:description}",
+						"# ${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = "#",
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = "#",
+						},
+						returns = {
+							enabled = true,
+							text = "#",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				items = {
-					layout = {
-						"# @return [${%snip_idx:type}] ${%snip_idx:description}",
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							enabled = false,
+							text = "#",
+						},
 					},
-					insert_gap_between = {
-						text = "#",
+					items = {
+						layout = {
+							"# @param %item_name [${%snip_idx:type}] ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "#",
+						},
+					},
+				},
+				{
+					name = "returns",
+					items = {
+						layout = {
+							"# @return [${%snip_idx:type}] ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "#",
+						},
 					},
 				},
 			},

--- a/lua/codedocs/config/languages/rust/styles/RustDoc.lua
+++ b/lua/codedocs/config/languages/rust/styles/RustDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/rust/styles/RustDoc.lua
+++ b/lua/codedocs/config/languages/rust/styles/RustDoc.lua
@@ -1,61 +1,63 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"/// ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						enabled = true,
-						text = "///",
-					},
-					returns = {
-						enabled = true,
-						text = "///",
-					},
-				},
-			},
-			{
-				name = "parameters",
-				layout = { "/// # Arguments", "///" },
-				gap_before = {
-					returns = {
-						enabled = true,
-						text = "///",
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "title",
 					layout = {
-						"/// * `%item_name` - ${%snip_idx:description}",
+						"/// ${%snip_idx:title}",
 					},
-					insert_gap_between = {
-						text = "///",
+					gap_before = {
+						parameters = {
+							enabled = true,
+							text = "///",
+						},
+						returns = {
+							enabled = true,
+							text = "///",
+						},
 					},
 				},
-			},
-			{
-				name = "returns",
-				layout = { "/// # Returns", "///" },
-				items = {
-					layout = {
-						"/// ${%snip_idx:description}",
+				{
+					name = "parameters",
+					layout = { "/// # Arguments", "///" },
+					gap_before = {
+						returns = {
+							enabled = true,
+							text = "///",
+						},
 					},
-					insert_gap_between = {
-						text = "///",
+					items = {
+						layout = {
+							"/// * `%item_name` - ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "///",
+						},
+					},
+				},
+				{
+					name = "returns",
+					layout = { "/// # Returns", "///" },
+					items = {
+						layout = {
+							"/// ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = "///",
+						},
 					},
 				},
 			},

--- a/lua/codedocs/config/languages/sql/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/sql/styles/Codedocs.lua
@@ -1,11 +1,13 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"-- ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"-- ${%snip_idx:description}",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/sql/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/sql/styles/Codedocs.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/toml/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/toml/styles/Codedocs.lua
@@ -1,11 +1,13 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"# ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"# ${%snip_idx:description}",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/toml/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/toml/styles/Codedocs.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/treesitter/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/treesitter/styles/Codedocs.lua
@@ -1,11 +1,13 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"; ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"; ${%snip_idx:description}",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/treesitter/styles/Codedocs.lua
+++ b/lua/codedocs/config/languages/treesitter/styles/Codedocs.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/config/languages/typescript/styles/TSDoc.lua
+++ b/lua/codedocs/config/languages/typescript/styles/TSDoc.lua
@@ -1,114 +1,116 @@
 return {
-	comment = {
-		placement = "current",
-		blocks = {
-			{
-				name = "title",
-				layout = {
-					"// ${%snip_idx:description}",
+	annots = {
+		comment = {
+			placement = "current",
+			blocks = {
+				{
+					name = "title",
+					layout = {
+						"// ${%snip_idx:description}",
+					},
 				},
 			},
 		},
-	},
-	class = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					attributes = {
-						text = " *",
-						enabled = true,
+		class = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
+					layout = {
+						"/**",
+						" * ${%snip_idx:title}",
+					},
+					gap_before = {
+						attributes = {
+							text = " *",
+							enabled = true,
+						},
 					},
 				},
-			},
-			{
-				name = "attributes",
-				gap_before = {
-					footer = {
-						text = " *",
-						enabled = false,
+				{
+					name = "attributes",
+					gap_before = {
+						footer = {
+							text = " *",
+							enabled = false,
+						},
+					},
+					items = {
+						insert_gap_between = {
+							text = " *",
+						},
 					},
 				},
-				items = {
-					insert_gap_between = {
-						text = " *",
+				{
+					name = "footer",
+					layout = {
+						" */",
 					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
 				},
 			},
 		},
-	},
-	func = {
-		placement = "above",
-		blocks = {
-			{
-				name = "header",
-				layout = {
-					"/**",
-					" * ${%snip_idx:title}",
-				},
-				gap_before = {
-					parameters = {
-						text = " *",
-						enabled = true,
-					},
-					returns = {
-						text = " *",
-						enabled = true,
-					},
-				},
-			},
-			{
-				name = "parameters",
-				gap_before = {
-					returns = {
-						text = " *",
-						enabled = false,
-					},
-				},
-				items = {
+		func = {
+			placement = "above",
+			blocks = {
+				{
+					name = "header",
 					layout = {
-						" * @param %item_name - ${%snip_idx:description}",
+						"/**",
+						" * ${%snip_idx:title}",
+					},
+					gap_before = {
+						parameters = {
+							text = " *",
+							enabled = true,
+						},
+						returns = {
+							text = " *",
+							enabled = true,
+						},
+					},
+				},
+				{
+					name = "parameters",
+					gap_before = {
+						returns = {
+							text = " *",
+							enabled = false,
+						},
+					},
+					items = {
+						layout = {
+							" * @param %item_name - ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
+					},
+				},
+				{
+					name = "returns",
+					gap_before = {
+						footer = {
+							text = " *",
+							enabled = false,
+						},
+					},
+					items = {
+						layout = {
+							" * @returns ${%snip_idx:description}",
+						},
+						insert_gap_between = {
+							text = " *",
+						},
+					},
+				},
+				{
+					name = "footer",
+					layout = {
+						" */",
 					},
 					insert_gap_between = {
 						text = " *",
 					},
-				},
-			},
-			{
-				name = "returns",
-				gap_before = {
-					footer = {
-						text = " *",
-						enabled = false,
-					},
-				},
-				items = {
-					layout = {
-						" * @returns ${%snip_idx:description}",
-					},
-					insert_gap_between = {
-						text = " *",
-					},
-				},
-			},
-			{
-				name = "footer",
-				layout = {
-					" */",
-				},
-				insert_gap_between = {
-					text = " *",
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/typescript/styles/TSDoc.lua
+++ b/lua/codedocs/config/languages/typescript/styles/TSDoc.lua
@@ -1,4 +1,5 @@
 return {
+	default_annot = "comment",
 	annots = {
 		comment = {
 			placement = "current",

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -62,12 +62,12 @@ function Codedocs.get_supported_langs() return vim.tbl_keys(require("codedocs.co
 function Codedocs.get_annotation_list()
 	local lang = _determine_lang_name()
 	local lang_stuff = require("codedocs.config").languages[lang]
-	local annotation_names = vim.tbl_keys(lang_stuff.styles[lang_stuff.default_style])
+	local annotation_names = vim.tbl_keys(lang_stuff.styles[lang_stuff.default_style].annots)
 	return annotation_names
 end
 
 ---Returns an existing annotation table from the configuration table
----Equivalent to `require("codedocs.config").languages[[lang_name]].styles[[style_name]][[annotation_name]]
+---Equivalent to `require("codedocs.config").languages[[lang_name]].styles[[style_name]].annots[[annotation_name]]
 ---@param lang_name string
 ---@param style_name string
 ---@param annotation_name string
@@ -79,7 +79,7 @@ function Codedocs.get_annotation_tbl(lang_name, style_name, annotation_name)
 		annotation_name = { annotation_name, "string" },
 	}
 
-	local annotation_tbl = require("codedocs.config").languages[lang_name].styles[style_name][annotation_name]
+	local annotation_tbl = require("codedocs.config").languages[lang_name].styles[style_name].annots[annotation_name]
 	return annotation_tbl
 end
 
@@ -137,8 +137,8 @@ local function validate_config(config)
 			[lang_path .. ".targets"] = { opts.targets, "table" },
 		}
 
-		for style_name, annotations in pairs(opts.styles) do
-			for annotation_name, annotation_opts in pairs(annotations) do
+		for style_name, style_opts in pairs(opts.styles) do
+			for annotation_name, annotation_opts in pairs(style_opts.annots) do
 				local annotation_path = lang_path .. (".styles.%s.%s"):format(style_name, annotation_name)
 
 				vim.validate {

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -321,15 +321,16 @@ function Codedocs.get_detected_annotation_data(lang_name)
 
 	local ttarget_data = _get_supported_target_node_data(node_at_cursor, Codedocs.get_target_identifiers(lang_name))
 
+	local lang_config = require("codedocs.config").languages[lang_name]
+
 	if not ttarget_data then
-		return {
-			items = {},
-			target_name = "comment",
-			row = vim.api.nvim_win_get_cursor(0)[1] - 1,
-		}
+		return Codedocs.get_requested_annotation_data(
+			lang_name,
+			lang_config.styles[lang_config.default_style].default_annot
+		)
 	end
 
-	local targets_config = require("codedocs.config").languages[lang_name].targets[ttarget_data.name]
+	local targets_config = lang_config.targets[ttarget_data.name]
 	local target_data = extractor.finish(ttarget_data, targets_config)
 
 	if not target_data then return end

--- a/tests/annotations/expanding_support_spec.lua
+++ b/tests/annotations/expanding_support_spec.lua
@@ -37,7 +37,9 @@ describe("Add support for a new language", function()
 					default_style = data.style_name,
 					styles = {
 						[data.style_name] = {
-							[data.annotation.name] = data.annotation.opts,
+							annots = {
+								[data.annotation.name] = data.annotation.opts,
+							},
 						},
 					},
 					targets = {},
@@ -89,7 +91,9 @@ describe("Adding new target-less annotation", function()
 				[lang_name] = {
 					styles = {
 						[style_name] = {
-							[annotation.name] = annotation.opts,
+							annots = {
+								[annotation.name] = annotation.opts,
+							},
 						},
 					},
 				},
@@ -182,7 +186,11 @@ describe("Add new annotation with target", function()
 			languages = {
 				lua = {
 					styles = {
-						EmmyLua = { [target.name] = annotation.opts },
+						EmmyLua = {
+							annots = {
+								[target.name] = annotation.opts,
+							},
+						},
 					},
 					targets = { [target.name] = target.opts },
 				},

--- a/tests/user_config/change_annotation_style_opts_spec.lua
+++ b/tests/user_config/change_annotation_style_opts_spec.lua
@@ -82,7 +82,9 @@ describe("Customizing style options", function()
 								[lang_name] = {
 									styles = {
 										[style_name] = {
-											[target_name] = original_mocked_user_opts,
+											annots = {
+												[target_name] = original_mocked_user_opts,
+											},
 										},
 									},
 								},


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Improves style flexibility and customizability

## Changes

- Wraps all annotation definitions with the new `annots` opt so that style-specific options can be set
- Styles can now use the `default_annot` to define a fallback annotation to be used when the autodetection feature fails

## Breaking changes

- [ ] Yes
- [x] No
