### PR TITLE
refactor(config): move validation next to opts definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,8 +404,8 @@ Because `blocks` replaces the entire default list, modifying a single block
 requires copying the original list first.
 
 ```lua
-local original_blocks =
-    require("codedocs.config").languages.python.styles.Google.func.blocks
+local config_opts = require("codedocs.config").opts
+local original_blocks = config_opts.languages.python.styles.Google.func.blocks
 
 local new_blocks = vim.deepcopy(original_blocks)
 

--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -1,5 +1,114 @@
 local dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h")
 
+local Config = {}
+
+local function validate_config(config)
+	vim.validate {
+		["config.logging"] = { config.logging, "table" },
+	}
+	vim.validate {
+		["config.logging.path"] = { config.logging.path, "string" },
+	}
+	vim.validate {
+		["config.logging.level"] = { config.logging.level, "number" },
+	}
+
+	vim.validate {
+		["config.languages"] = { config.languages, "table" },
+	}
+
+	for lang_name, opts in pairs(config.languages) do
+		local lang_path = ("config.languages.%s"):format(lang_name)
+		vim.validate {
+			[lang_path] = { opts, "table" },
+		}
+
+		vim.validate {
+			[lang_path .. ".default_style"] = { opts.default_style, "string" },
+		}
+		vim.validate {
+			[lang_path .. ".styles"] = { opts.styles, "table" },
+		}
+		vim.validate {
+			[lang_path .. ".targets"] = { opts.targets, "table" },
+		}
+
+		for style_name, style_opts in pairs(opts.styles) do
+			for annot_name, annotation_opts in pairs(style_opts.annots) do
+				local annotation_path = lang_path .. (".styles.%s.%s"):format(style_name, annot_name)
+
+				vim.validate {
+					[annotation_path] = {
+						annotation_opts,
+						"table",
+					},
+				}
+				vim.validate {
+					[annotation_path .. ".placement"] = {
+						annotation_opts.placement or annotation_opts.relative_position,
+						"string",
+					},
+				}
+
+				for idx, block in ipairs(annotation_opts.blocks) do
+					local block_idx_path = annotation_path .. ".blocks(" .. idx .. ")"
+					vim.validate {
+						[block_idx_path] = { block, "table" },
+					}
+
+					vim.validate {
+						[block_idx_path .. ".name"] = { block.name, "string" },
+					}
+
+					vim.validate {
+						[block_idx_path .. ".layout"] = { block.layout, "table" },
+					}
+					vim.validate {
+						[block_idx_path .. ".insert_gap_between"] = { block.insert_gap_between, "table" },
+					}
+					vim.validate {
+						[block_idx_path .. ".insert_gap_between.before"] = {
+							block.insert_gap_between.before,
+							"table",
+						},
+					}
+					vim.validate {
+						[block_idx_path .. ".insert_gap_between.text"] = { block.insert_gap_between.text, "string" },
+					}
+
+					if block.items then
+						vim.validate {
+							[block_idx_path .. " .items"] = { block.items, "table" },
+						}
+
+						vim.validate {
+							[block_idx_path .. ".items.layout"] = { block.items.layout, "table" },
+						}
+						vim.validate {
+							[block_idx_path .. ".items.insert_gap_between"] = {
+								block.items.insert_gap_between,
+								"table",
+							},
+						}
+						vim.validate {
+							[block_idx_path .. ".items.insert_gap_between.enabled"] = {
+								block.items.insert_gap_between.enabled,
+								"boolean",
+							},
+						}
+						vim.validate {
+							[block_idx_path .. ".items.insert_gap_between.text"] = {
+								block.items.insert_gap_between.text,
+								"string",
+							},
+						}
+					end
+				end
+			end
+		end
+	end
+end
+
 ---@alias CodedocsSupportedLanguages
 ---| "lua"
 ---| "python"
@@ -78,7 +187,7 @@ local function _build_dir_tbl(lang_name, subdir_name)
 end
 
 ---@type CodedocsConfig
-return {
+Config.opts = {
 	logging = {
 		level = vim.log.levels.INFO,
 		path = (vim.fn.stdpath "log") .. "/codedocs.log",
@@ -134,3 +243,25 @@ return {
 		},
 	},
 }
+
+function Config.setup(user_config)
+	vim.validate {
+		user_config = { user_config, "table" },
+	}
+
+	if not user_config then return end
+
+	local opts = Config.opts
+	local merged = vim.tbl_deep_extend("force", opts, user_config)
+
+	for k in pairs(opts) do
+		opts[k] = nil
+	end
+	for k, v in pairs(merged) do
+		opts[k] = v
+	end
+
+	validate_config(merged)
+end
+
+return Config

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -35,7 +35,7 @@ end
 
 local function _determine_lang_name()
 	if not Codedocs._filetypes_map then
-		local langs_config = require("codedocs.config").languages
+		local langs_config = require("codedocs.config").opts.languages
 		local filetypes_map = {}
 		for lang_name, opts in pairs(langs_config) do
 			for _, filetype_name in ipairs(opts.filetypes) do
@@ -49,17 +49,17 @@ local function _determine_lang_name()
 	return Codedocs._filetypes_map[vim.bo.filetype]
 end
 
-function Codedocs.get_supported_langs() return vim.tbl_keys(require("codedocs.config").languages) end
+function Codedocs.get_supported_langs() return vim.tbl_keys(require("codedocs.config").opts.languages) end
 
 function Codedocs.get_annot_list()
 	local lang = _determine_lang_name()
-	local lang_stuff = require("codedocs.config").languages[lang]
+	local lang_stuff = require("codedocs.config").opts.languages[lang]
 	local annot_names = vim.tbl_keys(lang_stuff.styles[lang_stuff.default_style].annots)
 	return annot_names
 end
 
 ---Returns an existing annotation table from the configuration table
----Equivalent to `require("codedocs.config").languages[[lang_name]].styles[[style_name]].annots[[annotation_name]]
+---Equivalent to `require("codedocs.config").opts.languages[[lang_name]].styles[[style_name]].annots[[annotation_name]]
 ---@param lang_name string
 ---@param style_name string
 ---@param annot_name string
@@ -71,19 +71,19 @@ function Codedocs.get_annot_tbl(lang_name, style_name, annot_name)
 		annot_name = { annot_name, "string" },
 	}
 
-	local annot_tbl = require("codedocs.config").languages[lang_name].styles[style_name].annots[annot_name]
+	local annot_tbl = require("codedocs.config").opts.languages[lang_name].styles[style_name].annots[annot_name]
 	return annot_tbl
 end
 
 ---@return string[] supported_styles List of style names
 function Codedocs.get_supported_styles(lang_name)
-	local supported_styles = vim.tbl_keys(require("codedocs.config").languages[lang_name].styles)
+	local supported_styles = vim.tbl_keys(require("codedocs.config").opts.languages[lang_name].styles)
 	table.sort(supported_styles)
 	return supported_styles
 end
 
 function Codedocs.get_target_identifiers(lang_name)
-	local targets_data = require("codedocs.config").languages[lang_name].targets
+	local targets_data = require("codedocs.config").opts.languages[lang_name].targets
 
 	if targets_data._identifiers then return targets_data._identifiers end
 
@@ -98,136 +98,15 @@ function Codedocs.get_target_identifiers(lang_name)
 	return target_identifiers
 end
 
-local function validate_config(config)
-	vim.validate {
-		["config.logging"] = { config.logging, "table" },
-	}
-	vim.validate {
-		["config.logging.path"] = { config.logging.path, "string" },
-	}
-	vim.validate {
-		["config.logging.level"] = { config.logging.level, "number" },
-	}
-
-	vim.validate {
-		["config.languages"] = { config.languages, "table" },
-	}
-
-	for lang_name, opts in pairs(config.languages) do
-		local lang_path = ("config.languages.%s"):format(lang_name)
-		vim.validate {
-			[lang_path] = { opts, "table" },
-		}
-
-		vim.validate {
-			[lang_path .. ".default_style"] = { opts.default_style, "string" },
-		}
-		vim.validate {
-			[lang_path .. ".styles"] = { opts.styles, "table" },
-		}
-		vim.validate {
-			[lang_path .. ".targets"] = { opts.targets, "table" },
-		}
-
-		for style_name, style_opts in pairs(opts.styles) do
-			for annot_name, annotation_opts in pairs(style_opts.annots) do
-				local annotation_path = lang_path .. (".styles.%s.%s"):format(style_name, annot_name)
-
-				vim.validate {
-					[annotation_path] = {
-						annotation_opts,
-						"table",
-					},
-				}
-				vim.validate {
-					[annotation_path .. ".placement"] = {
-						annotation_opts.placement or annotation_opts.relative_position,
-						"string",
-					},
-				}
-
-				for idx, block in ipairs(annotation_opts.blocks) do
-					local block_idx_path = annotation_path .. ".blocks(" .. idx .. ")"
-					vim.validate {
-						[block_idx_path] = { block, "table" },
-					}
-
-					vim.validate {
-						[block_idx_path .. ".name"] = { block.name, "string" },
-					}
-
-					vim.validate {
-						[block_idx_path .. ".layout"] = { block.layout, "table" },
-					}
-					vim.validate {
-						[block_idx_path .. ".insert_gap_between"] = { block.insert_gap_between, "table" },
-					}
-					vim.validate {
-						[block_idx_path .. ".insert_gap_between.before"] = {
-							block.insert_gap_between.before,
-							"table",
-						},
-					}
-					vim.validate {
-						[block_idx_path .. ".insert_gap_between.text"] = { block.insert_gap_between.text, "string" },
-					}
-
-					if block.items then
-						vim.validate {
-							[block_idx_path .. " .items"] = { block.items, "table" },
-						}
-
-						vim.validate {
-							[block_idx_path .. ".items.layout"] = { block.items.layout, "table" },
-						}
-						vim.validate {
-							[block_idx_path .. ".items.insert_gap_between"] = {
-								block.items.insert_gap_between,
-								"table",
-							},
-						}
-						vim.validate {
-							[block_idx_path .. ".items.insert_gap_between.enabled"] = {
-								block.items.insert_gap_between.enabled,
-								"boolean",
-							},
-						}
-						vim.validate {
-							[block_idx_path .. ".items.insert_gap_between.text"] = {
-								block.items.insert_gap_between.text,
-								"string",
-							},
-						}
-					end
-				end
-			end
-		end
-	end
-end
-
 ---@param user_config CodedocsConfig?
 function Codedocs.setup(user_config)
 	Logger.info "Setup called"
 	Logger.debug("Setup options: " .. vim.inspect(user_config))
 
-	vim.validate {
-		user_config = { user_config, "table" },
-	}
+	local Config = require "codedocs.config"
+	Config.setup(user_config)
 
-	if not user_config then return end
-
-	local config = require "codedocs.config"
-	local merged = vim.tbl_deep_extend("force", config, user_config)
-
-	for k in pairs(config) do
-		config[k] = nil
-	end
-	for k, v in pairs(merged) do
-		config[k] = v
-	end
-
-	validate_config(merged)
-	Logger.debug("Merged config options: " .. vim.inspect(merged))
+	Logger.debug("Merged config options: " .. vim.inspect(Config.opts))
 end
 
 ---@param ts_node TSNode Treesitter node to traverse upwards from
@@ -246,7 +125,7 @@ end
 function Codedocs.get_requested_annot_data(lang_name, requested_name)
 	local cursor_row = vim.api.nvim_win_get_cursor(0)[1] - 1
 
-	local lang_config = require("codedocs.config").languages[lang_name]
+	local lang_config = require("codedocs.config").opts.languages[lang_name]
 
 	--- Returned when no annotation targets are available, or when using
 	--- Treesitter and no matching node is found under the cursor.
@@ -260,7 +139,7 @@ function Codedocs.get_requested_annot_data(lang_name, requested_name)
 
 	local extractor = require "codedocs.item_extractor"
 
-	local targets_config = require("codedocs.config").languages[lang_name].targets[requested_name]
+	local targets_config = require("codedocs.config").opts.languages[lang_name].targets[requested_name]
 
 	if not targets_config.node_identifiers or vim.tbl_isempty(targets_config.node_identifiers) then
 		local data = extractor.finish({}, targets_config)
@@ -313,7 +192,7 @@ function Codedocs.get_detected_annot_data(lang_name)
 
 	local ttarget_data = _get_supported_target_node_data(node_at_cursor, Codedocs.get_target_identifiers(lang_name))
 
-	local lang_config = require("codedocs.config").languages[lang_name]
+	local lang_config = require("codedocs.config").opts.languages[lang_name]
 
 	if not ttarget_data then
 		return Codedocs.get_requested_annot_data(lang_name, lang_config.styles[lang_config.default_style].default_annot)
@@ -341,7 +220,7 @@ function Codedocs.build_annot(lang_name, data)
 	}
 
 	local annot_tbl = Codedocs.get_annot_tbl(lang_name, data.style_name, data.target_name)
-	local opts = require("codedocs.config").annot_builder
+	local opts = require("codedocs.config").opts.annot_builder
 
 	local Annot_builder = require "codedocs.annot_builder"
 	local annot = Annot_builder.new(data.row + 1, opts)
@@ -364,7 +243,7 @@ function Codedocs.get_annot_data(lang_name, annotation_data)
 		annotation_data = { annotation_data, { "table", "nil" } },
 	}
 
-	local lang_config = require("codedocs.config").languages[lang_name]
+	local lang_config = require("codedocs.config").opts.languages[lang_name]
 	local user_requested_specific_annotation = annotation_data and annotation_data.annot_name
 
 	local annot_data

--- a/lua/codedocs/utils/logger.lua
+++ b/lua/codedocs/utils/logger.lua
@@ -16,7 +16,7 @@ local function _log(msg, level)
 		level = { level, "number" },
 	}
 
-	local config = require("codedocs.config").logging
+	local config = require("codedocs.config").opts.logging
 	if level < config.level then return end
 
 	local path = vim.fs.normalize(config.path)

--- a/tests/annots/builder/builder_spec.lua
+++ b/tests/annots/builder/builder_spec.lua
@@ -35,7 +35,7 @@ describe("Annotation builder - ", function()
 			local blocks = require("tests.annots.builder.cases." .. case_name .. ".input_blocks")
 			local expected_output = vim.fn.readfile(DIR .. "/cases/" .. case_name .. "/output")
 
-			local opts = require("codedocs.config").annot_builder
+			local opts = require("codedocs.config").opts.annot_builder
 			local annot = annot_builder.new(nil, opts)
 			annot:insert_blocks(blocks, MOCKED_ITEMS)
 

--- a/tests/annots/defaults/annotations_spec.lua
+++ b/tests/annots/defaults/annotations_spec.lua
@@ -35,7 +35,7 @@ local function test_case(lang, style_name, annot_name, case_name)
 end
 
 describe("Default style annotations", function()
-	local langs_config = require("codedocs.config").languages
+	local langs_config = require("codedocs.config").opts.languages
 
 	for _, lang in ipairs(LANGS_TO_TEST) do
 		for style_name, annots in pairs(langs_config[lang].styles) do

--- a/tests/item_extraction/presence_detection/presence_detection_spec.lua
+++ b/tests/item_extraction/presence_detection/presence_detection_spec.lua
@@ -1,5 +1,5 @@
 local Utils = require "tests.utils"
-local config = require "codedocs.config"
+local config = require("codedocs.config").opts
 local Codedocs = require "codedocs"
 
 local DIR = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h")

--- a/tests/item_extraction/type_detection/type_detection_spec.lua
+++ b/tests/item_extraction/type_detection/type_detection_spec.lua
@@ -1,5 +1,5 @@
 local Utils = require "tests.utils"
-local config = require "codedocs.config"
+local config = require("codedocs.config").opts
 local Codedocs = require "codedocs"
 
 local DIR = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h")

--- a/tests/user_config/change_lang_default_style_spec.lua
+++ b/tests/user_config/change_lang_default_style_spec.lua
@@ -1,5 +1,5 @@
 local Utils = require "tests.utils"
-local config = require "codedocs.config"
+local config = require("codedocs.config").opts
 
 Utils.for_style(function(lang_name, style_name)
 	insulate("Setting default style (" .. lang_name .. "):", function()


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Moves the config validation next to the config options

## Breaking changes

- [ ] Yes
- [x] No
