### PR TITLE
fix: python default parameter items not being extracted

### DIFF
--- a/queries/python/codedocs_func_params.scm
+++ b/queries/python/codedocs_func_params.scm
@@ -4,5 +4,9 @@
 			(identifier) @item_name
 			(#not-eq? @item_name "self")
 			(type) @item_type)
+		(typed_default_parameter
+			(identifier) @item_name
+			(#not-eq? @item_name "self")
+			(type) @item_type)
 		(identifier) @item_name (#not-eq? @item_name "self")
 	])


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

As described in #147, the plugin is currently not extracting parameters that are defined with a default value

## Changes

- Updates the python func Treesitter query to include typed default parameters

## Breaking changes

- [ ] Yes
- [x] No
