### PR TITLE
feat!: overhaul annotation options with new `item blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ _A simple, customizable, yet powerful Annotation Framework_
   - [Languages](#languages)
     - [Targets](#targets)
     - [Annotations](#annotations)
+      - [Blocks](#blocks)
+        - [General blocks](#general-blocks)
+        - [Item blocks](#item-blocks)
 - [Language support](#language-support)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -323,38 +326,36 @@ Annotations are defined as a table with specific options.
 
 ##### Blocks
 
-Blocks define the structure and rendering of an annotation.
-
-The `blocks` option is a list of block definitions. Each block is responsible
-for rendering a specific section, such as parameters, returns, attributes, etc.
-
 <!-- prettier-ignore -->
 > [!IMPORTANT]
-> `blocks` is a list, so overriding it replaces the default list entirely.
+> Overriding a list of blocks replaces the default list entirely.
 >
-> To modify a single block, see
-> [Customizing blocks](#customizing-blocks).
+> To modify a single block, see [Customizing blocks](#customizing-blocks).
 
-###### Block options
+Blocks are the fundamental building blocks of an annotation. Each block defines
+how a portion of the annotation is rendered, including its layout, formatting,
+and any associated behavior.
 
-| Option Name  | Type     | Description                                                      |
-| ------------ | -------- | ---------------------------------------------------------------- |
-| `name`       | string   | Block identifier used by `gap_before`                            |
-| `item_names` | string[] | Defines what items are to be used in a block                     |
-| `layout`     | string[] | Block lines. Supports [layout placeholders](#configuration)      |
-| `gap_before` | table    | Inserts spacing before another block                             |
-| `items`      | `table?` | Defines item rendering and spacing. See [`items`](#items-option) |
+There are two types of blocks: general blocks and item blocks. Item blocks are
+an extension of general blocks, adding a small set of item-specific features.
 
-###### `items` option
+<!-- prettier-ignore -->
+###### General blocks
 
-The `items` option controls how extracted items are rendered inside a block.
+All blocks support the following options:
 
-| Name                 | Expected Value Type                 | Behavior                                              |
-| -------------------- | ----------------------------------- | ----------------------------------------------------- |
-| `layout`             | `string[]`                          | Same as `layout`, but with item-specific placeholders |
-| `insert_gap_between` | `{text: string, enabled = boolean}` | Whether to insert a gap between items                 |
+| Option Name  | Type                                                      | Description                                                             |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `name`       | string                                                    | Block identifier used by other options                                  |
+| `layout`     | string[]                                                  | Block lines. Supports [layout placeholders](#configuration)             |
+| `gap_before` | `{ [block_name] = { enabled = boolean, text = string } }` | Maps block `name` values to the gap inserted before the matching block. |
+| `items`      | `table?`                                                  | List of item blocks                                                     |
 
-###### `gap_before`
+The `layout` option supports the following placeholders:
+
+- `%snip_idx`: Tabstop index for Neovim snippets. The counter is increased by 1
+  after each use
+- `%%>`: One level of indentation based on your Neovim settings
 
 Each key in `gap_before` is a block name, and its value supports the following
 suboptions:
@@ -375,16 +376,30 @@ gap_before = {
 },
 ```
 
-###### `item_names` option
+###### Item blocks
 
-When items are extracted from a target, they are grouped by name. For a block to
-access those items, the group name for said items must be in the `item_names`
-list.
+Item blocks are defined in a list under the `items` key of a general block.
+
+When items are extracted from a target, they are grouped by name. For an item
+block to access those items, the group name for said items must be the same as
+the name of the block.
 
 For example, given a `func` target with `parameters` and `returns` item groups,
-a block with "parameters" inside the `item_names` list will automatically have
-access to those items and can render them via `items.layout`, with support for
+a block named "parameters" will automatically have access to the `parameter`
+items and can define how they render via the `layout` option, with support for
 placeholders.
+
+When used in an item block, the `layout` option supports the following
+additional placeholders, in addition to the general placeholders:
+
+- `%item_name`: The item's name.
+- `%item_type`: The item's type.
+
+Lastly, item blocks have the following exclusive options:
+
+| Name                 | Expected Value Type                 | Behavior                              |
+| -------------------- | ----------------------------------- | ------------------------------------- |
+| `insert_gap_between` | `{text: string, enabled = boolean}` | Whether to insert a gap between items |
 
 ###### Customizing blocks
 
@@ -461,9 +476,17 @@ require("codedocs").setup {
                                     },
                                 },
                                 items = {
-                                    layout = {
-                                        "%>:param %item_name: ${%snip_idx:description}",
-                                        "%>:type %item_name: ${%snip_idx:%item_type}",
+                                    {
+                                        name = "parameters",
+                                        layout = {
+                                            "%>:param %item_name: ${%snip_idx:description}",
+                                            "%>:type %item_name: ${%snip_idx:%item_type}",
+                                        },
+                                        insert_gap_between = {
+                                            enabled = false,
+                                            text = "",
+                                        },
+                                        gap_before = {},
                                     },
                                 },
                             },
@@ -476,9 +499,17 @@ require("codedocs").setup {
                                     },
                                 },
                                 items = {
-                                    layout = {
-                                        "%>:return: ${%snip_idx:description}",
-                                        "%>:rtype: ${%snip_idx:%item_type}",
+                                    {
+                                        name = "returns",
+                                        layout = {
+                                            "%>:return: ${%snip_idx:description}",
+                                            "%>:rtype: ${%snip_idx:%item_type}",
+                                        },
+                                        insert_gap_between = {
+                                            enabled = false,
+                                            text = "",
+                                        },
+                                        gap_before = {},
                                     },
                                 },
                             },

--- a/lua/codedocs/annotation_builder.lua
+++ b/lua/codedocs/annotation_builder.lua
@@ -1,0 +1,125 @@
+local Annot_builder = {}
+Annot_builder.__index = Annot_builder
+
+function Annot_builder.new(items, builder_config, row)
+	local obj = {
+		placeholders = {
+			general = {},
+			items = {},
+		},
+		state = {
+			lines = {},
+			snip_idx_counter = 1,
+		},
+		items = items,
+		line_indent = (function()
+			local cols = vim.fn.indent(row + 1)
+			if cols == -1 then return "" end
+
+			if vim.bo.expandtab then return string.rep(" ", cols) end
+
+			local tabstop = vim.bo.tabstop
+			local tabs = math.floor(cols / tabstop)
+			local spaces = cols % tabstop
+
+			return string.rep("\t", tabs) .. string.rep(" ", spaces)
+		end)(),
+	}
+	obj = vim.tbl_deep_extend("force", obj, vim.deepcopy(builder_config))
+
+	setmetatable(obj, Annot_builder)
+	return obj
+end
+
+function Annot_builder:apply_general_placeholder(str)
+	for placeholder, handler in pairs(self.placeholders.general) do
+		str = str:gsub(placeholder, function() return handler(self.state) end)
+	end
+
+	return str
+end
+
+function Annot_builder:apply_item_placeholder(str, item)
+	for placeholder, handler in pairs(self.placeholders.items) do
+		str = str:gsub(placeholder, function() return handler(self.state, item) end)
+		str = self:apply_general_placeholder(str)
+	end
+
+	return str
+end
+
+function Annot_builder:build_items_group_lines(group_items, layout, gap)
+	if #group_items == 0 then return {} end
+
+	local group_lines = {}
+
+	for idx, item in ipairs(group_items) do
+		for _, layout_line in ipairs(layout) do
+			table.insert(group_lines, self:apply_item_placeholder(layout_line, item))
+
+			if idx < #group_items and gap and gap.enabled then
+				table.insert(group_lines, self:apply_general_placeholder(gap.text))
+			end
+		end
+	end
+
+	return group_lines
+end
+
+function Annot_builder:block(blocks, is_item)
+	local content = {}
+
+	local gap_data
+	for _, block in ipairs(blocks) do
+		local block_lines = {}
+		if is_item then
+			local block_items = self.items[block.name]
+			if block_items then
+				block_lines = self:build_items_group_lines(block_items, block.layout, block.insert_gap_between)
+			end
+		elseif block.items and not vim.tbl_isempty(block.items) then
+			block_lines = {}
+			local items_lines = self:block(block.items, true)
+
+			-- emit this block's own layout
+			if not vim.tbl_isempty(items_lines) then
+				for _, ln in ipairs(block.layout or {}) do
+					table.insert(block_lines, self:apply_general_placeholder(ln))
+				end
+				vim.list_extend(block_lines, items_lines)
+			end
+		else
+			for _, ln in ipairs(block.layout) do
+				table.insert(block_lines, self:apply_general_placeholder(ln))
+			end
+		end
+
+		if
+			-- idx < #blocks
+			#block_lines > 0
+			and gap_data
+			and gap_data[block.name]
+			and gap_data[block.name].enabled
+		then
+			table.insert(content, gap_data[block.name].text)
+		end
+
+		vim.list_extend(content, block_lines)
+
+		if #block_lines > 0 then gap_data = block.gap_before end
+	end
+
+	if vim.tbl_isempty(content) then return {} end
+
+	return content
+end
+
+function Annot_builder:build(blocks)
+	local block_lines = self:block(blocks, false)
+
+	vim.list_extend(self.state.lines, block_lines)
+
+	return self.state.lines
+end
+
+return Annot_builder

--- a/lua/codedocs/config/customization_spec.lua
+++ b/lua/codedocs/config/customization_spec.lua
@@ -41,7 +41,6 @@ describe_customization("Adding new target-less annotation", function()
 			blocks = {
 				{
 					name = "title",
-					item_names = {},
 					insert_gap_between = {
 						text = "",
 						before = {},
@@ -92,32 +91,28 @@ describe_customization("Add new annotation with target", function()
 			blocks = {
 				{
 					name = "title",
-					item_names = {},
 					layout = {
 						"---first line",
 					},
-					insert_gap_between = {
-						text = "",
-						before = {},
-					},
+					gap_before = {},
 				},
 				{
 					name = "someblock",
-					item_names = { "someblock" },
 					layout = {
 						"---${%snip_idx:block title}",
 					},
-					insert_gap_between = {
-						text = "",
-						before = {},
-					},
+					gap_before = {},
 					items = {
-						layout = {
-							"%item_name | %item_type",
-						},
-						insert_gap_between = {
-							enabled = false,
-							text = "",
+						{
+							name = "someblock",
+							layout = {
+								"%item_name | %item_type",
+							},
+							insert_gap_between = {
+								enabled = false,
+								text = "",
+							},
+							gap_before = {},
 						},
 					},
 				},
@@ -224,7 +219,7 @@ local BASE_MOCKED_OPTS = {
 			layout = {
 				"some layout %item_name",
 			},
-			indent = true,
+			gap_before = {},
 		},
 	},
 }
@@ -297,7 +292,6 @@ describe_customization("Add support for a new language", function()
 				blocks = {
 					{
 						name = "title",
-						item_names = {},
 						insert_gap_between = {
 							text = "",
 							before = {},
@@ -306,6 +300,7 @@ describe_customization("Add support for a new language", function()
 							"---${%snip_idx:title}",
 							"---Second line",
 						},
+						gap_before = {},
 					},
 				},
 			},

--- a/lua/codedocs/config/init.lua
+++ b/lua/codedocs/config/init.lua
@@ -63,45 +63,65 @@ local function validate_config(config)
 					vim.validate {
 						[block_idx_path .. ".layout"] = { block.layout, "table" },
 					}
-					vim.validate {
-						[block_idx_path .. ".insert_gap_between"] = { block.insert_gap_between, "table" },
-					}
-					vim.validate {
-						[block_idx_path .. ".insert_gap_between.before"] = {
-							block.insert_gap_between.before,
-							"table",
-						},
-					}
-					vim.validate {
-						[block_idx_path .. ".insert_gap_between.text"] = { block.insert_gap_between.text, "string" },
-					}
 
 					if block.items then
 						vim.validate {
 							[block_idx_path .. " .items"] = { block.items, "table" },
 						}
 
-						vim.validate {
-							[block_idx_path .. ".items.layout"] = { block.items.layout, "table" },
-						}
-						vim.validate {
-							[block_idx_path .. ".items.insert_gap_between"] = {
-								block.items.insert_gap_between,
-								"table",
-							},
-						}
-						vim.validate {
-							[block_idx_path .. ".items.insert_gap_between.enabled"] = {
-								block.items.insert_gap_between.enabled,
-								"boolean",
-							},
-						}
-						vim.validate {
-							[block_idx_path .. ".items.insert_gap_between.text"] = {
-								block.items.insert_gap_between.text,
-								"string",
-							},
-						}
+						for item_block_idx, item_block in ipairs(block.items) do
+							vim.validate {
+								[block_idx_path .. ".items[" .. item_block_idx .. "].name"] = {
+									item_block.name,
+									"string",
+								},
+							}
+							vim.validate {
+								[block_idx_path .. ".items[" .. item_block_idx .. "].layout"] = {
+									item_block.layout,
+									"table",
+								},
+							}
+							vim.validate {
+								[block_idx_path .. "items[" .. item_block_idx .. "].insert_gap_between"] = {
+									item_block.insert_gap_between,
+									"table",
+								},
+							}
+							vim.validate {
+								[block_idx_path .. ".items[" .. item_block_idx .. "].insert_gap_between.enabled"] = {
+									item_block.insert_gap_between.enabled,
+									"boolean",
+								},
+							}
+							vim.validate {
+								[block_idx_path .. ".items[" .. item_block_idx .. "].insert_gap_between.text"] = {
+									item_block.insert_gap_between.text,
+									"string",
+								},
+							}
+							vim.validate {
+								[block_idx_path .. ".items[" .. item_block_idx .. "].gap_before"] = {
+									item_block.gap_before,
+									"table",
+								},
+							}
+
+							for block_name, gap_opts in ipairs(item_block.gap_before) do
+								vim.validate {
+									[block_idx_path .. ".items[" .. item_block_idx .. "].gap_before[" .. block_name .. "].enabled"] = {
+										gap_opts.enabled,
+										"boolean",
+									},
+								}
+								vim.validate {
+									[block_idx_path .. ".items[" .. item_block_idx .. "].gap_before[" .. block_name .. "].text"] = {
+										gap_opts.text,
+										"string",
+									},
+								}
+							end
+						end
 					end
 				end
 			end

--- a/lua/codedocs/config/languages/bash/styles/Google/comment/init.lua
+++ b/lua/codedocs/config/languages/bash/styles/Google/comment/init.lua
@@ -3,10 +3,10 @@ return {
 	blocks = {
 		{
 			name = "title",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},
+			gap_before = {},
 		},
 	},
 }

--- a/lua/codedocs/config/languages/bash/styles/Google/func/init.lua
+++ b/lua/codedocs/config/languages/bash/styles/Google/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"#######################################",
 				"# ${%snip_idx:title}",
@@ -11,25 +10,51 @@ return {
 		},
 		{
 			name = "globals",
-			item_names = { "globals" },
 			layout = { "# Globals:" },
-			items = { layout = { "#   %item_name" } },
+			items = {
+				{
+					name = "globals",
+					layout = { "#   %item_name" },
+					insert_gap_between = {
+						enabled = false,
+						text = " #",
+					},
+					gap_before = {},
+				},
+			},
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			layout = { "# Arguments:" },
-			items = { layout = { "#   ${%snip_idx:description}" } },
+			items = {
+				{
+					name = "parameters",
+					layout = { "#   ${%snip_idx:description}" },
+					insert_gap_between = {
+						enabled = false,
+						text = " #",
+					},
+					gap_before = {},
+				},
+			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			layout = { "Returns:" },
-			items = { layout = { "%item_type:" } },
+			items = {
+				{
+					name = "returns",
+					layout = { "%item_type:" },
+					insert_gap_between = {
+						enabled = false,
+						text = " #",
+					},
+					gap_before = {},
+				},
+			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				"#######################################",
 			},

--- a/lua/codedocs/config/languages/bash/styles/Google/shebang/init.lua
+++ b/lua/codedocs/config/languages/bash/styles/Google/shebang/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "title",
-			item_names = {},
 			layout = {
 				"#${%snip_idx:!/usr/bin/env bash}",
 			},

--- a/lua/codedocs/config/languages/c/styles/Doxygen/comment/init.lua
+++ b/lua/codedocs/config/languages/c/styles/Doxygen/comment/init.lua
@@ -3,10 +3,10 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},
+			gap_before = {},
 		},
 	},
 }

--- a/lua/codedocs/config/languages/c/styles/Doxygen/func/init.lua
+++ b/lua/codedocs/config/languages/c/styles/Doxygen/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -29,13 +27,22 @@ return {
 				},
 			},
 			items = {
-				layout = { " * @param %item_name ${%snip_idx:description}" },
-				insert_gap_between = { text = " *" },
+				{
+					name = "parameters",
+					layout = { " * @param %item_name ${%snip_idx:description}" },
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
+				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -43,18 +50,28 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @return ${%snip_idx:description}",
+				{
+					name = "returns",
+					layout = {
+						" * @return ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
-				insert_gap_between = { text = " *" },
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},
+			gap_before = {},
 		},
 	},
 }

--- a/lua/codedocs/config/languages/cpp/styles/Doxygen/comment/init.lua
+++ b/lua/codedocs/config/languages/cpp/styles/Doxygen/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/cpp/styles/Doxygen/func/init.lua
+++ b/lua/codedocs/config/languages/cpp/styles/Doxygen/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -29,15 +27,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @param %item_name ${%snip_idx:description}",
+				{
+					name = "parameters",
+					layout = {
+						" * @param %item_name ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
-				insert_gap_between = { text = " *" },
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -45,15 +52,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @return ${%snip_idx:description}",
+				{
+					name = "returns",
+					layout = {
+						" * @return ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
-				insert_gap_between = { text = " *" },
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/gdscript/styles/Codedocs/comment/init.lua
+++ b/lua/codedocs/config/languages/gdscript/styles/Codedocs/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/gdscript/styles/Codedocs/export/init.lua
+++ b/lua/codedocs/config/languages/gdscript/styles/Codedocs/export/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "title",
-			item_names = {},
 			layout = {
 				"@export ${%snip_idx:property}",
 			},

--- a/lua/codedocs/config/languages/gdscript/styles/Codedocs/on_ready/init.lua
+++ b/lua/codedocs/config/languages/gdscript/styles/Codedocs/on_ready/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"@onready ${%snip_idx:property}",
 			},

--- a/lua/codedocs/config/languages/gdscript/styles/Codedocs/warning_ignore/init.lua
+++ b/lua/codedocs/config/languages/gdscript/styles/Codedocs/warning_ignore/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'@warning_ignore("${%snip_idx:warning}")',
 			},

--- a/lua/codedocs/config/languages/go/styles/Godoc/comment/init.lua
+++ b/lua/codedocs/config/languages/go/styles/Godoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/go/styles/Godoc/func/init.lua
+++ b/lua/codedocs/config/languages/go/styles/Godoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "title",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:title}",
 			},
@@ -16,19 +15,44 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
+			layout = {},
 			gap_before = {
 				returns = {
 					enabled = false,
 					text = "//",
 				},
 			},
-			items = { insert_gap_between = { text = "//" } },
+			items = {
+				{
+					name = "parameters",
+					layout = {},
+					insert_gap_between = {
+						enabled = false,
+						text = "//",
+					},
+					gap_before = {
+						enabled = false,
+						text = "//",
+					},
+				},
+			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
-			items = { insert_gap_between = { text = "//" } },
+			items = {
+				{
+					name = "returns",
+					layout = {},
+					insert_gap_between = {
+						enabled = false,
+						text = "//",
+					},
+					gap_before = {
+						enabled = false,
+						text = "//",
+					},
+				},
+			},
 		},
 	},
 }

--- a/lua/codedocs/config/languages/html/styles/Codedocs/comment/init.lua
+++ b/lua/codedocs/config/languages/html/styles/Codedocs/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"<!-- ${%snip_idx:description} -->",
 			},

--- a/lua/codedocs/config/languages/java/styles/JavaDoc/class/init.lua
+++ b/lua/codedocs/config/languages/java/styles/JavaDoc/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
 			layout = { " * Attributes:" },
 			gap_before = {
 				footer = {
@@ -29,11 +27,23 @@ return {
 					text = " *",
 				},
 			},
-			items = { layout = { "// %item_name" }, insert_gap_between = { text = " *" } },
+			items = {
+				{
+					name = "attributes",
+					layout = { "// %item_name" },
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
+				},
+			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/java/styles/JavaDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/java/styles/JavaDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "title",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/java/styles/JavaDoc/func/init.lua
+++ b/lua/codedocs/config/languages/java/styles/JavaDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					text = " *",
@@ -29,15 +27,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @param %item_name ${%snip_idx:description}",
+				{
+					name = "parameters",
+					layout = {
+						" * @param %item_name ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
-				insert_gap_between = { text = " *" },
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -45,15 +52,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @return ${%snip_idx:description}",
+				{
+					name = "returns",
+					layout = {
+						" * @return ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
-				insert_gap_between = { text = " *" },
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/javascript/styles/JSDoc/class/init.lua
+++ b/lua/codedocs/config/languages/javascript/styles/JSDoc/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -17,7 +16,6 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -25,17 +23,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @property {%item_type} %item_name ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "attributes",
+					layout = {
+						" * @property {%item_type} %item_name ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/javascript/styles/JSDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/javascript/styles/JSDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/javascript/styles/JSDoc/func/init.lua
+++ b/lua/codedocs/config/languages/javascript/styles/JSDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:description}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -29,17 +27,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @param {${%snip_idx:type}} %item_name ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "parameters",
+					layout = {
+						" * @param {${%snip_idx:type}} %item_name ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -47,17 +52,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @returns {${%snip_idx:type}} ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "returns",
+					layout = {
+						" * @returns {${%snip_idx:type}} ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/kotlin/styles/KDoc/class/init.lua
+++ b/lua/codedocs/config/languages/kotlin/styles/KDoc/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -17,18 +16,29 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
 			gap_before = {
 				footer = {
 					enabled = false,
 					text = " *",
 				},
 			},
-			items = { insert_gap_between = { text = " *" } },
+			items = {
+				{
+					name = "attributes",
+					layout = {},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
+				},
+			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/kotlin/styles/KDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/kotlin/styles/KDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/kotlin/styles/KDoc/func/init.lua
+++ b/lua/codedocs/config/languages/kotlin/styles/KDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -29,17 +27,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @param %item_name ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "parameters",
+					layout = {
+						" * @param %item_name ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -47,17 +52,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @return ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "returns",
+					layout = {
+						" * @return ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/lua/styles/EmmyLua/comment/init.lua
+++ b/lua/codedocs/config/languages/lua/styles/EmmyLua/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"---${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/lua/styles/EmmyLua/func/init.lua
+++ b/lua/codedocs/config/languages/lua/styles/EmmyLua/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"---${%snip_idx:title}",
 			},
@@ -20,7 +19,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -28,23 +26,38 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"---@param %item_name ${%snip_idx:type} ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "---",
+				{
+					name = "parameters",
+					layout = {
+						"---@param %item_name ${%snip_idx:type} ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "---",
+					},
+					gap_before = {
+						returns = {
+							enabled = true,
+							text = "---",
+						},
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
+			layout = {},
 			items = {
-				layout = {
-					"---@return ${%snip_idx:type} ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "---",
+				{
+					name = "returns",
+					layout = {
+						"---@return ${%snip_idx:type} ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "---",
+					},
+					gap_before = {},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/lua/styles/LDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/lua/styles/LDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"-- ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/lua/styles/LDoc/func/init.lua
+++ b/lua/codedocs/config/languages/lua/styles/LDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"--- ${%snip_idx:title}",
 			},
@@ -20,7 +19,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -28,23 +26,38 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"-- @param %item_name ${%snip_idx:type} ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "--",
+				{
+					name = "parameters",
+					layout = {
+						"-- @param %item_name ${%snip_idx:type} ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "--",
+					},
+					gap_before = {
+						enabled = false,
+						text = "--",
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			items = {
-				layout = {
-					"-- @return ${%snip_idx:type} ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "--",
+				{
+					name = "returns",
+					layout = {
+						"-- @return ${%snip_idx:type} ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "--",
+					},
+					gap_before = {
+						enabled = false,
+						text = "--",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/markdown/styles/Codedocs/comment/init.lua
+++ b/lua/codedocs/config/languages/markdown/styles/Codedocs/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"<!-- ${%snip_idx:description} -->",
 			},

--- a/lua/codedocs/config/languages/php/styles/PHPDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/php/styles/PHPDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/php/styles/PHPDoc/func/init.lua
+++ b/lua/codedocs/config/languages/php/styles/PHPDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					text = " *",
@@ -29,17 +27,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @param ${%snip_idx:%item_type} \\$%item_name ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "parameters",
+					layout = {
+						" * @param ${%snip_idx:%item_type} \\$%item_name ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					text = " *",
@@ -47,17 +52,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @return ${%snip_idx:%item_type} ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "returns",
+					layout = {
+						" * @return ${%snip_idx:%item_type} ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/php/styles/PHPDoc/phptag/init.lua
+++ b/lua/codedocs/config/languages/php/styles/PHPDoc/phptag/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"<?php",
 				"${%snip_idx:code}",

--- a/lua/codedocs/config/languages/python/styles/Google/class/init.lua
+++ b/lua/codedocs/config/languages/python/styles/Google/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'%>"""',
 				"%>${%snip_idx:title}",
@@ -17,7 +16,6 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
 			layout = { "%>Attributes:" },
 			gap_before = {
 				footer = {
@@ -26,17 +24,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>%item_name (%item_type): ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "",
+				{
+					name = "attributes",
+					layout = {
+						"%>%item_name (%item_type): ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {
+						enabled = false,
+						text = "",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				'%>"""',
 			},

--- a/lua/codedocs/config/languages/python/styles/Google/comment/init.lua
+++ b/lua/codedocs/config/languages/python/styles/Google/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/python/styles/Google/func/init.lua
+++ b/lua/codedocs/config/languages/python/styles/Google/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'%>"""',
 				"%>${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			layout = { "%>Args:" },
 			gap_before = {
 				returns = {
@@ -30,14 +28,21 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>%>%item_name (${%snip_idx:%item_type}): ${%snip_idx:description}",
+				{
+					name = "parameters",
+					layout = {
+						"%>%>%item_name (${%snip_idx:%item_type}): ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			layout = { "%>Returns:" },
 			gap_before = {
 				footer = {
@@ -46,14 +51,21 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>%>${%snip_idx:%item_type}: ${%snip_idx:description}",
+				{
+					name = "returns",
+					layout = {
+						"%>%>${%snip_idx:%item_type}: ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				'%>"""',
 			},

--- a/lua/codedocs/config/languages/python/styles/NumPy/class/init.lua
+++ b/lua/codedocs/config/languages/python/styles/NumPy/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'%>"""',
 				"%>${%snip_idx:title}",
@@ -17,24 +16,30 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
+			layout = { "%>Attributes:", "%>___________" },
 			gap_before = {
 				footer = {
 					enabled = false,
 					text = "",
 				},
 			},
-			layout = { "%>Attributes:", "%>___________" },
 			items = {
-				layout = {
-					"%>%item_name : ${%snip_idx:%item_type}",
-					"%>	${%snip_idx:description}",
+				{
+					name = "attributes",
+					layout = {
+						"%>%item_name : ${%snip_idx:%item_type}",
+						"%>	${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				'%>"""',
 			},

--- a/lua/codedocs/config/languages/python/styles/NumPy/comment/init.lua
+++ b/lua/codedocs/config/languages/python/styles/NumPy/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/python/styles/NumPy/func/init.lua
+++ b/lua/codedocs/config/languages/python/styles/NumPy/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'%>"""',
 				"%>${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			layout = { "%>Parameters", "%>----------" },
 			gap_before = {
 				returns = {
@@ -30,15 +28,22 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>%item_name: ${%snip_idx:%item_type}",
-					"%>	${%snip_idx:description}",
+				{
+					name = "parameters",
+					layout = {
+						"%>%item_name: ${%snip_idx:%item_type}",
+						"%>	${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			layout = { "%>Returns", "%>-------" },
 			gap_before = {
 				footer = {
@@ -47,15 +52,22 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>${%snip_idx:%item_type}",
-					"%>	${%snip_idx:description}",
+				{
+					name = "returns",
+					layout = {
+						"%>${%snip_idx:%item_type}",
+						"%>	${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				'%>"""',
 			},

--- a/lua/codedocs/config/languages/python/styles/reST/class/init.lua
+++ b/lua/codedocs/config/languages/python/styles/reST/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'%>"""',
 				"%>${%snip_idx:title}",
@@ -17,7 +16,6 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
 			gap_before = {
 				footer = {
 					text = "",
@@ -25,15 +23,22 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>:var %item_name: ${%snip_idx:description}",
-					"%>:vartype %item_name: ${%snip_idx:%item_type}",
+				{
+					name = "attributes",
+					layout = {
+						"%>:var %item_name: ${%snip_idx:description}",
+						"%>:vartype %item_name: ${%snip_idx:%item_type}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				'%>"""',
 			},

--- a/lua/codedocs/config/languages/python/styles/reST/comment/init.lua
+++ b/lua/codedocs/config/languages/python/styles/reST/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/python/styles/reST/func/init.lua
+++ b/lua/codedocs/config/languages/python/styles/reST/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				'%>"""',
 				"%>${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -29,15 +27,22 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>:param %item_name: ${%snip_idx:description}",
-					"%>:type %item_name: ${%snip_idx:%item_type}",
+				{
+					name = "parameters",
+					layout = {
+						"%>:param %item_name: ${%snip_idx:description}",
+						"%>:type %item_name: ${%snip_idx:%item_type}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					enabled = false,
@@ -45,15 +50,22 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"%>:return: ${%snip_idx:description}",
-					"%>:rtype: ${%snip_idx:%item_type}",
+				{
+					name = "returns",
+					layout = {
+						"%>:return: ${%snip_idx:description}",
+						"%>:rtype: ${%snip_idx:%item_type}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "",
+					},
+					gap_before = {},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				'%>"""',
 			},

--- a/lua/codedocs/config/languages/ruby/styles/YARD/comment/init.lua
+++ b/lua/codedocs/config/languages/ruby/styles/YARD/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/ruby/styles/YARD/func/init.lua
+++ b/lua/codedocs/config/languages/ruby/styles/YARD/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:title}",
 			},
@@ -20,7 +19,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					enabled = false,
@@ -28,23 +26,38 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"# @param %item_name [${%snip_idx:type}] ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "#",
+				{
+					name = "parameters",
+					layout = {
+						"# @param %item_name [${%snip_idx:type}] ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "#",
+					},
+					gap_before = {
+						enabled = false,
+						text = "#",
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			items = {
-				layout = {
-					"# @return [${%snip_idx:type}] ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "#",
+				{
+					name = "returns",
+					layout = {
+						"# @return [${%snip_idx:type}] ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "#",
+					},
+					gap_before = {
+						enabled = false,
+						text = "#",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/rust/styles/RustDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/rust/styles/RustDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/rust/styles/RustDoc/func/init.lua
+++ b/lua/codedocs/config/languages/rust/styles/RustDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/// ${%snip_idx:title}",
 			},
@@ -20,7 +19,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			layout = { "/// # Arguments", "///" },
 			gap_before = {
 				returns = {
@@ -29,24 +27,39 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					"/// * `%item_name` - ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "///",
+				{
+					name = "parameters",
+					layout = {
+						"/// * `%item_name` - ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "///",
+					},
+					gap_before = {
+						text = "///",
+						enabled = false,
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			layout = { "/// # Returns", "///" },
 			items = {
-				layout = {
-					"/// ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = "///",
+				{
+					name = "returns",
+					layout = {
+						"/// ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = "///",
+					},
+					gap_before = {
+						enabled = false,
+						text = "///",
+					},
 				},
 			},
 		},

--- a/lua/codedocs/config/languages/sql/styles/Codedocs/comment/init.lua
+++ b/lua/codedocs/config/languages/sql/styles/Codedocs/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"-- ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/toml/styles/Codedocs/comment/init.lua
+++ b/lua/codedocs/config/languages/toml/styles/Codedocs/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"# ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/treesitter/styles/Codedocs/comment/init.lua
+++ b/lua/codedocs/config/languages/treesitter/styles/Codedocs/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"; ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/typescript/styles/TSDoc/class/init.lua
+++ b/lua/codedocs/config/languages/typescript/styles/TSDoc/class/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -17,7 +16,6 @@ return {
 		},
 		{
 			name = "attributes",
-			item_names = { "attributes" },
 			gap_before = {
 				footer = {
 					text = " *",
@@ -25,14 +23,22 @@ return {
 				},
 			},
 			items = {
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "attributes",
+					layout = {},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
 			},

--- a/lua/codedocs/config/languages/typescript/styles/TSDoc/comment/init.lua
+++ b/lua/codedocs/config/languages/typescript/styles/TSDoc/comment/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"// ${%snip_idx:description}",
 			},

--- a/lua/codedocs/config/languages/typescript/styles/TSDoc/func/init.lua
+++ b/lua/codedocs/config/languages/typescript/styles/TSDoc/func/init.lua
@@ -3,7 +3,6 @@ return {
 	blocks = {
 		{
 			name = "header",
-			item_names = {},
 			layout = {
 				"/**",
 				" * ${%snip_idx:title}",
@@ -21,7 +20,6 @@ return {
 		},
 		{
 			name = "parameters",
-			item_names = { "parameters" },
 			gap_before = {
 				returns = {
 					text = " *",
@@ -29,17 +27,24 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @param %item_name - ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "parameters",
+					layout = {
+						" * @param %item_name - ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "returns",
-			item_names = { "returns" },
 			gap_before = {
 				footer = {
 					text = " *",
@@ -47,22 +52,26 @@ return {
 				},
 			},
 			items = {
-				layout = {
-					" * @returns ${%snip_idx:description}",
-				},
-				insert_gap_between = {
-					text = " *",
+				{
+					name = "returns",
+					layout = {
+						" * @returns ${%snip_idx:description}",
+					},
+					insert_gap_between = {
+						enabled = false,
+						text = " *",
+					},
+					gap_before = {
+						enabled = false,
+						text = " *",
+					},
 				},
 			},
 		},
 		{
 			name = "footer",
-			item_names = {},
 			layout = {
 				" */",
-			},
-			insert_gap_between = {
-				text = " *",
 			},
 		},
 	},

--- a/lua/codedocs/init.lua
+++ b/lua/codedocs/init.lua
@@ -3,94 +3,11 @@ local Item_extractor = require "codedocs.item_extractor"
 
 local Codedocs = {}
 
-local function _get_line_indent(row)
-	local cols = vim.fn.indent(row + 1)
-	if cols == -1 then return "" end
-
-	if vim.bo.expandtab then return string.rep(" ", cols) end
-
-	local tabstop = vim.bo.tabstop
-	local tabs = math.floor(cols / tabstop)
-	local spaces = cols % tabstop
-
-	return string.rep("\t", tabs) .. string.rep(" ", spaces)
-end
-
 function Codedocs.build_annot_lines(blocks, opts, row, items)
-	local state = {
-		placeholders = {
-			general = {},
-			items = {},
-		},
-		lines = {},
-	}
+	local annot = require("codedocs.annotation_builder").new(items, opts, row)
+	local lines = annot:build(blocks)
 
-	local new_state = vim.tbl_deep_extend("force", state, vim.deepcopy(opts))
-
-	new_state.placeholders.items =
-		vim.tbl_deep_extend("force", new_state.placeholders.items, vim.deepcopy(new_state.placeholders.general))
-
-	local line_indent = _get_line_indent(row)
-
-	local function insert(line, item)
-		if line == "" then
-			table.insert(new_state.lines, line)
-			return
-		end
-
-		line = line_indent .. line
-
-		local placeholders = item and new_state.placeholders.items or new_state.placeholders.general
-
-		for placeholder, handler in pairs(placeholders) do
-			line = line:gsub(placeholder, function() return handler(new_state.state, item) end)
-		end
-
-		table.insert(new_state.lines, line)
-	end
-
-	local function new_block(block_opts, block_items)
-		for _, layout_line in ipairs(block_opts.layout) do
-			insert(layout_line)
-		end
-
-		if not block_items then return end
-
-		for item_idx, item in ipairs(block_items) do
-			for _, line in ipairs(block_opts.items.layout) do
-				insert(line, item)
-
-				local is_last_item = block_items[item_idx + 1] == nil
-				if block_opts.items.insert_gap_between.enabled and not is_last_item then
-					insert(block_opts.items.insert_gap_between.text, item)
-				end
-			end
-		end
-	end
-
-	local gap_data
-
-	for _, block in ipairs(blocks) do
-		local is_item_based_block = type(block.items) == "table"
-
-		local block_items = {}
-		for _, items_name_to_use in ipairs(block.item_names) do
-			if items[items_name_to_use] then vim.list_extend(block_items, items[items_name_to_use]) end
-		end
-
-		local at_least_one_block_item = block_items and #block_items > 0 and #block.items.layout > 0
-
-		if not is_item_based_block or at_least_one_block_item then
-			if gap_data and gap_data[block.name] and gap_data[block.name].enabled then
-				insert(gap_data[block.name].text)
-			end
-
-			new_block(block, block_items)
-			gap_data = block.gap_before
-		end
-	end
-
-	return new_state.lines
+	return lines
 end
 
 --- Inserts an annotation relative to a target and moves the cursor to the annotation title

--- a/tests/annots/builder/cases/a/input_blocks.lua
+++ b/tests/annots/builder/cases/a/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"---",
 			"--* ",
@@ -15,64 +14,47 @@ return {
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
 		layout = {},
-		insert_gap_between = {
+		gap_before = {
 			text = " *",
 		},
 		items = {
-			layout = {
-				"--* @item %item_name",
-			},
-			insert_gap_between = {
-				text = " *",
-			},
-			items = {
-				insert_gap_between = {
-					enabled = false,
-					text = " * ",
-				},
-				indent = false,
+			{
+				name = "primary_section",
 				layout = {
-					" * @item %item_name",
+					"--* @item %item_name",
+				},
+				gap_before = {
+					text = " *",
 				},
 			},
 		},
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		insert_gap_between = {
 			text = " * ",
 		},
 		items = {
-			layout = {
-				"--* @secondary_item %item_name",
-			},
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			items = {
-				insert_gap_between = {
+			{
+				name = "secondary_section",
+				layout = {
+					"--* @secondary_item %item_name",
+				},
+				gap_before = {
 					enabled = false,
 					text = " * ",
-				},
-				indent = false,
-				layout = {
-					" * @secondary_item %item_name",
 				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" ]-",
 		},
-		insert_gap_between = {
+		gap_before = {
 			text = " *",
 		},
 	},

--- a/tests/annots/builder/cases/b/input_blocks.lua
+++ b/tests/annots/builder/cases/b/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"/**",
 			" * ",
@@ -15,7 +14,6 @@ return {
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
 		layout = {},
 		gap_before = {
 			secondary_section = {
@@ -24,43 +22,36 @@ return {
 			},
 		},
 		items = {
-			layout = {
-				" * @item %item_name",
-			},
-			insert_gap_between = {
-				enabled = false,
-				text = " *",
-			},
-			items = {
-				insert_gap_between = {
-					enabled = false,
-					text = " * ",
-				},
-				indent = false,
+			{
+				name = "primary_section",
 				layout = {
 					" * @item %item_name",
+				},
+				gap_before = {
+					enabled = false,
+					text = " *",
 				},
 			},
 		},
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			indent = false,
-			layout = {
-				" * @secondary_item %item_name",
+			{
+				name = "secondary_section",
+				layout = {
+					" * @secondary_item %item_name",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" */",
 		},

--- a/tests/annots/builder/cases/c/input_blocks.lua
+++ b/tests/annots/builder/cases/c/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"/**",
 			" * ",
@@ -15,7 +14,6 @@ return {
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		gap_before = {
 			primary_section = {
@@ -24,42 +22,41 @@ return {
 			},
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			indent = false,
-			layout = {
-				" * @secondary_item %item_name",
+			{
+				name = "secondary_section",
+				layout = {
+					" * @secondary_item %item_name",
+				},
 			},
 		},
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
+		layout = {
+			" * This is the primary section",
+			" * ***************************",
+			" * ",
+		},
 		gap_before = {
 			footer = {
 				enabled = false,
 				text = " *",
 			},
 		},
-		layout = {
-			" * This is the primary section",
-			" * ***************************",
-			" * ",
-		},
 		items = {
-			layout = {
-				" * @item %item_name",
-			},
-			insert_gap_between = {
-				text = " *",
+			{
+				name = "primary_section",
+				layout = {
+					" * @item %item_name",
+				},
+				gap_before = {
+					text = " *",
+				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" */",
 		},

--- a/tests/annots/builder/cases/control/input_blocks.lua
+++ b/tests/annots/builder/cases/control/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"/**",
 			" * ",
@@ -15,7 +14,6 @@ return {
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
 		layout = {},
 		gap_before = {
 			secondary_section = {
@@ -24,18 +22,20 @@ return {
 			},
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			layout = {
-				" * @item %item_name",
+			{
+				name = "primary_section",
+				layout = {
+					" * @item %item_name",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		gap_before = {
 			footer = {
@@ -44,18 +44,20 @@ return {
 			},
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			layout = {
-				" * @secondary_item %item_name",
+			{
+				name = "secondary_section",
+				layout = {
+					" * @secondary_item %item_name",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" */",
 		},

--- a/tests/annots/builder/cases/d/input_blocks.lua
+++ b/tests/annots/builder/cases/d/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"/**",
 			" * ",
@@ -15,7 +14,6 @@ return {
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
 		layout = {},
 		gap_before = {
 			secondary_section = {
@@ -24,18 +22,24 @@ return {
 			},
 		},
 		items = {
-			layout = {
-				" * @item %item_name",
-			},
-			insert_gap_between = {
-				enabled = true,
-				text = " * ",
+			{
+				name = "primary_section",
+				layout = {
+					" * @item %item_name",
+				},
+				insert_gap_between = {
+					enabled = true,
+					text = " * ",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		gap_before = {
 			footer = {
@@ -44,18 +48,24 @@ return {
 			},
 		},
 		items = {
-			insert_gap_between = {
-				enabled = true,
-				text = " * ",
-			},
-			layout = {
-				" * @secondary_item %item_name",
+			{
+				name = "secondary_section",
+				layout = {
+					" * @secondary_item %item_name",
+				},
+				insert_gap_between = {
+					enabled = true,
+					text = " * ",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" */",
 		},

--- a/tests/annots/builder/cases/e/input_blocks.lua
+++ b/tests/annots/builder/cases/e/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"/**",
 			" * ",
@@ -15,7 +14,6 @@ return {
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
 		layout = {},
 		gap_before = {
 			secondary_section = {
@@ -24,18 +22,20 @@ return {
 			},
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			layout = {
-				" * @the_type [%item_type] @the_name {%item_name}",
+			{
+				name = "primary_section",
+				layout = {
+					" * @the_type [%item_type] @the_name {%item_name}",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		gap_before = {
 			footer = {
@@ -44,18 +44,20 @@ return {
 			},
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			layout = {
-				" * @secondary_item %item_name",
+			{
+				name = "secondary_section",
+				layout = {
+					" * @secondary_item %item_name",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" */",
 		},

--- a/tests/annots/builder/cases/f/input_blocks.lua
+++ b/tests/annots/builder/cases/f/input_blocks.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		name = "header",
-		item_names = {},
 		layout = {
 			"/**",
 			" * ",
@@ -15,43 +14,46 @@ return {
 	},
 	{
 		name = "primary_section",
-		item_names = { "primary_section" },
 		layout = {},
 		gap_before = {
 			text = " *",
 			enabled = false,
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			layout = {
-				" * @the_type [%item_type] @the_name {%item_name} ${%snip_idx:description}",
+			{
+				name = "primary_section",
+				layout = {
+					" * @the_type [%item_type] @the_name {%item_name} ${%snip_idx:description}",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "secondary_section",
-		item_names = { "secondary_section" },
 		layout = {},
 		gap_before = {
 			text = " * ",
 			enabled = false,
 		},
 		items = {
-			insert_gap_between = {
-				enabled = false,
-				text = " * ",
-			},
-			layout = {
-				" * @secondary_item %item_name",
+			{
+				name = "secondary_section",
+				layout = {
+					" * @secondary_item %item_name",
+				},
+				gap_before = {
+					enabled = false,
+					text = " * ",
+				},
 			},
 		},
 	},
 	{
 		name = "footer",
-		item_names = {},
 		layout = {
 			" */",
 		},


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Improves upon the concept of `block` by adding `item blocks` which can be processed recursively as they share the same base structure, thus reusing concepts whilst making the plugin more powerful and customizable

## Changes

- Turns the `items` option into a list of item blocks
- Removes the `items_names` option
- Updates all relevant tests and docs

## Breaking changes

- [x] Yes
- [ ] No
