### PR TITLE
feat(languages/params): add default params support

### DIFF
--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,1 @@
+void foo(int a = 5) {}

--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,1 @@
+void foo(int a = 5, int b = 6, int c = 7) {}

--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "int" },
+			{ name = "b", type = "int" },
+			{ name = "c", type = "int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,1 @@
+void foo(int a = 5, int b = 6) {}

--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "int" },
+			{ name = "b", type = "int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/cpp/targets/func/parameters/queries/parameters.scm
+++ b/lua/codedocs/config/languages/cpp/targets/func/parameters/queries/parameters.scm
@@ -1,19 +1,37 @@
 (function_definition
 	(function_declarator
 		(parameter_list
-			(parameter_declaration
-				type: [
-					(primitive_type)
-					(qualified_identifier)
-					(struct_specifier
-						(type_identifier))
-					(sized_type_specifier)
-					(type_identifier)
-				] @item_type
-				[
-					(identifier)
-					(pointer_declarator
-						(identifier))
-					(reference_declarator
-						(identifier))
-				] @item_name))))
+			[
+				(parameter_declaration
+					type: [
+						(primitive_type)
+						(qualified_identifier)
+						(struct_specifier
+							(type_identifier))
+						(sized_type_specifier)
+						(type_identifier)
+					] @item_type
+					[
+						(identifier)
+						(pointer_declarator
+							(identifier))
+						(reference_declarator
+							(identifier))
+					] @item_name)
+				(optional_parameter_declaration
+					type: [
+						(primitive_type)
+						(qualified_identifier)
+						(struct_specifier
+							(type_identifier))
+						(sized_type_specifier)
+						(type_identifier)
+					] @item_type
+					[
+						(identifier)
+						(pointer_declarator
+							(identifier))
+						(reference_declarator
+							(identifier))
+					] @item_name)
+			])))

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,2 @@
+function foo(a = 5) {
+}

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,2 @@
+function foo(a = 5, b = 6, c = 7) {
+}

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+			{ name = "c", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,2 @@
+function foo(a = 5, b = 6) {
+}

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/javascript/targets/func/parameters/queries/parameters.scm
+++ b/lua/codedocs/config/languages/javascript/targets/func/parameters/queries/parameters.scm
@@ -1,15 +1,29 @@
 [
 	(method_definition
-		(formal_parameters
-			(identifier) @item_name
+		parameters: (formal_parameters
+			[
+				(identifier) @item_name
+				(assignment_pattern
+					(identifier) @item_name)
+			]
 		)
 	)
 	(function_declaration
-		(formal_parameters
-			(identifier) @item_name
+		parameters: (formal_parameters
+			[
+				(identifier) @item_name
+				(assignment_pattern
+					(identifier) @item_name)
+			]
 		)
 	)
 	(arrow_function
 		parameters: (formal_parameters
-			(identifier) @item_name))
+			[
+				(identifier) @item_name
+				(assignment_pattern
+					(identifier) @item_name)
+			]
+		)
+	)
 ]

--- a/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,1 @@
+fun foo(a: Int = 5) {}

--- a/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "Int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,1 @@
+fun foo(a: Int = 5, b: Int = 6, c: Int = 7) {}

--- a/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "Int" },
+			{ name = "b", type = "Int" },
+			{ name = "c", type = "Int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,1 @@
+fun foo(a: Int = 5, b: Int = 6) {}

--- a/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/kotlin/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "Int" },
+			{ name = "b", type = "Int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,3 @@
+<?php
+function foo(int $a = 5) {
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 3, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_untyped_default_param/input
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_untyped_default_param/input
@@ -1,0 +1,3 @@
+<?php
+function foo($a = 5) {
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_untyped_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/one_untyped_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 3, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,3 @@
+<?php
+function foo(int $a = 5, int $b = 6, int $c = 7) {
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 3, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "int" },
+			{ name = "b", type = "int" },
+			{ name = "c", type = "int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_untyped_default_params/input
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_untyped_default_params/input
@@ -1,0 +1,3 @@
+<?php
+function foo($a = 5, $b = 6, $c = 7) {
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_untyped_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/three_untyped_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 3, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+			{ name = "c", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,3 @@
+<?php
+function foo(int $a = 5, int $b = 6) {
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 3, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "int" },
+			{ name = "b", type = "int" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_untyped_default_params/input
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_untyped_default_params/input
@@ -1,0 +1,3 @@
+<?php
+function foo($a = 5, $b = 6) {
+}

--- a/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_untyped_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/php/targets/func/parameters/extraction_cases/item_detection/two_untyped_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 3, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,2 @@
+def foo(a = 1):
+	pass

--- a/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,2 @@
+def foo(a = 1, b = 2, c = 3):
+	pass

--- a/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+			{ name = "c", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,2 @@
+def foo(a = 1, b = 2):
+	pass

--- a/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/python/targets/func/parameters/queries/parameters.scm
+++ b/lua/codedocs/config/languages/python/targets/func/parameters/queries/parameters.scm
@@ -8,5 +8,9 @@
 			(identifier) @item_name
 			(#not-eq? @item_name "self")
 			(type) @item_type)
+		(default_parameter
+			(identifier) @item_name
+			(#not-eq? @item_name "self")
+		)
 		(identifier) @item_name (#not-eq? @item_name "self")
 	])

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,2 @@
+def foo(a = 5)
+end

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,2 @@
+def foo(a = 5, b = 6, c = 7)
+end

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+			{ name = "c", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,2 @@
+def foo(a = 5, b = 6)
+end

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "" },
+			{ name = "b", type = "" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/ruby/targets/func/parameters/queries/parameters.scm
+++ b/lua/codedocs/config/languages/ruby/targets/func/parameters/queries/parameters.scm
@@ -1,3 +1,6 @@
 (method
 	(method_parameters
-		(identifier) @item_name))
+		[
+			(identifier) @item_name
+			(optional_parameter (identifier) @item_name)
+		]))

--- a/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
+++ b/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/one_default_param/input
@@ -1,0 +1,1 @@
+function foo(a: number = 5): void {}

--- a/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
+++ b/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/one_default_param/metadata.lua
@@ -1,0 +1,9 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "number" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
+++ b/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/three_default_params/input
@@ -1,0 +1,1 @@
+function foo(a: number = 5, b: number = 6, c: number = 7): void {}

--- a/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/three_default_params/metadata.lua
@@ -1,0 +1,11 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "number" },
+			{ name = "b", type = "number" },
+			{ name = "c", type = "number" },
+		},
+		returns = {},
+	},
+}

--- a/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
+++ b/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/two_default_params/input
@@ -1,0 +1,1 @@
+function foo(a: number = 5, b: number = 6): void {}

--- a/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
+++ b/lua/codedocs/config/languages/typescript/targets/func/parameters/extraction_cases/item_detection/two_default_params/metadata.lua
@@ -1,0 +1,10 @@
+return {
+	cursor_pos = { row = 1, col = 1 },
+	expected_items = {
+		parameters = {
+			{ name = "a", type = "number" },
+			{ name = "b", type = "number" },
+		},
+		returns = {},
+	},
+}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Description

Codedocs can now extract default parameters in the following languages:

- PHP
- Python
- Kotlin
- JavaScript/TypeScript
- C++
- Ruby

No other supported language includes default parameters in its grammar.

## Breaking changes

- [ ] Yes
- [x] No
